### PR TITLE
メール認証情報の環境変数化とヘルスチェック調整

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      MAIL_USERNAME: ${{ secrets.MAIL_USERNAME }}
+      MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+          cache: gradle
+      - name: Build with Gradle
+        run: ./gradlew build
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       DATABASE_URL: jdbc:postgresql://db:5432/giiku_db_autotest
       DATABASE_USERNAME: postgres
       DATABASE_PASSWORD: postgres
+      MAIL_USERNAME: ${MAIL_USERNAME}
+      MAIL_PASSWORD: ${MAIL_PASSWORD}
     ports:
       - "8080:8080"
     depends_on:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,8 +83,8 @@ spring:
   mail:
     host: ${MAIL_HOST:localhost}
     port: ${MAIL_PORT:587}
-    username: ${MAIL_USERNAME:}
-    password: ${MAIL_PASSWORD:}
+    username: ${MAIL_USERNAME:your-secure-username}
+    password: ${MAIL_PASSWORD:your-secure-password}
     properties:
       mail:
         smtp:
@@ -169,3 +169,6 @@ management:
   endpoint:
     health:
       show-details: when-authorized
+  health:
+    mail:
+      enabled: false


### PR DESCRIPTION
## Summary
- spring.mail の username と password を本番向け環境変数に対応
- mail のヘルスチェックを無効化
- CI ワークフローと docker-compose で MAIL_* 環境変数を渡す設定を追加

## Testing
- `./gradlew build`
- `docker-compose config`


------
https://chatgpt.com/codex/tasks/task_b_68962157440883248c7b9aadb847db2f