### PR TITLE
ダッシュボードにindexコンテンツを直接埋め込み

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 - Java は [Amazon Corretto](https://aws.amazon.com/corretto/) を使用
 - IDE は [Pleiades](https://pleiades.io/) を推奨
 
-## 進捗状況（2025-08-07時点）
+## 進捗状況（2025-08-08時点）
 - **全体進捗:** 56%
 - **月別ページ:** 100%
 - **週別ページ:** 100%
@@ -73,6 +73,9 @@
 - バックエンド：Slack通知とログ機能を復元
 - バックエンド：共通コントローラとダッシュボードを再導入
 - バックエンド：AbstractController・Dashboard・ログイン画面のテストを再追加
+- フロントエンド：dashboard.htmlをindex.htmlのスタイルに合わせて更新
+- フロントエンド：dashboard.htmlをlayout.htmlを利用する構造に変更
+- フロントエンド：ダッシュボードにindex.htmlの静的コンテンツを直接埋め込み
 
 ## 今後のタスク（優先順位順）
 1. `day6.html`〜`day54.html` の作成（残り49日分）

--- a/progress_and_planning.html
+++ b/progress_and_planning.html
@@ -44,6 +44,10 @@
         <div class="bg-white rounded-lg shadow-md p-6 mb-6">
             <h2 class="text-2xl font-bold text-custom-blue mb-4">プロジェクト概要</h2>
         <p class="mb-4">このプロジェクトは、IT未経験者を3ヶ月間で基礎から応用まで育成するための総合カリキュラムのWebサイト作成です。全54日分のカリキュラム内容を日別・週別・月別に整理し、体系的な学習環境を提供します。</p>
+        <p class="text-gray-600 text-sm mb-2">2025-08-08: dashboard.htmlにindex.htmlの静的コンテンツを直接埋め込み。</p>
+        <p class="text-gray-600 text-sm mb-2">2025-08-07: dashboard.htmlにindex.htmlの静的コンテンツを表示。</p>
+        <p class="text-gray-600 text-sm mb-2">2025-08-07: dashboard.htmlをindex.htmlのスタイルに合わせて更新。</p>
+        <p class="text-gray-600 text-sm mb-2">2025-08-07: dashboard.htmlがlayout.htmlを利用するよう修正。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-07: AbstractController・Dashboard・ログイン画面のテストを追加。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-06: エンティティとリポジトリにJavaDocコメントと入力チェックを追加。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-06: Day46〜Day54講義ページに標準ナビゲーションを追加。</p>
@@ -397,7 +401,7 @@
     <footer class="bg-custom-blue text-white py-4 mt-6">
         <div class="container mx-auto px-4 text-center">
             <p>&copy; 2025 ITエンジニア育成カリキュラム All Rights Reserved.</p>
-            <p class="text-sm mt-2">最終更新日: 2025-08-06</p>
+            <p class="text-sm mt-2">最終更新日: 2025-08-08</p>
         </div>
     </footer>
 

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -1,16 +1,446 @@
 <!DOCTYPE html>
-<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<html lang="ja" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security" th:replace="~{layout :: layout(~{::body})}">
 <head>
     <meta charset="UTF-8">
-    <title>ダッシュボード - 技育システム</title>
-    <link href="/webjars/bootstrap/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link th:href="@{/css/giiku-style.css}" rel="stylesheet">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ダッシュボード | APSA</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --apsa-primary: #2c3e50;
+            --apsa-secondary: #3498db;
+            --apsa-accent: #e74c3c;
+            --apsa-success: #27ae60;
+            --apsa-warning: #f39c12;
+            --apsa-light: #ecf0f1;
+            --apsa-dark: #34495e;
+        }
+        body {
+            font-family: 'Noto Sans JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            line-height: 1.6;
+            color: #333;
+        }
+        .hero-section {
+            background: linear-gradient(135deg, var(--apsa-primary) 0%, var(--apsa-secondary) 100%);
+            color: #fff;
+            min-height: 70vh;
+            display: flex;
+            align-items: center;
+        }
+        .hero-content h1 {
+            font-size: clamp(2rem, 5vw, 3.5rem);
+            font-weight: 700;
+            margin-bottom: 1.5rem;
+        }
+        .hero-content p {
+            font-size: 1.25rem;
+            margin-bottom: 2rem;
+        }
+        .progress-chart-container {
+            position: relative;
+            height: 300px;
+            margin: 2rem 0;
+        }
+        .stat-card {
+            background: linear-gradient(135deg, var(--apsa-secondary), var(--apsa-primary));
+            color: #fff;
+            border-radius: 15px;
+            padding: 2rem;
+            text-align: center;
+            margin-bottom: 1rem;
+        }
+        .stat-number {
+            font-size: 3rem;
+            font-weight: 700;
+            margin-bottom: 0.5rem;
+        }
+        .feature-icon {
+            width: 80px;
+            height: 80px;
+            border-radius: 50%;
+            background: linear-gradient(135deg, var(--apsa-secondary), var(--apsa-primary));
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0 auto 1rem;
+            color: #fff;
+            font-size: 2rem;
+        }
+        .month-card .card-header {
+            background: linear-gradient(135deg, var(--apsa-secondary), var(--apsa-primary));
+            color: #fff;
+            border: none;
+            font-weight: 600;
+        }
+        .timeline {
+            position: relative;
+            padding: 20px 0;
+        }
+        .timeline-item {
+            position: relative;
+            padding: 20px 0 20px 60px;
+            border-left: 2px solid var(--apsa-light);
+        }
+        .timeline-item:before {
+            content: '';
+            position: absolute;
+            left: -8px;
+            top: 25px;
+            width: 14px;
+            height: 14px;
+            border-radius: 50%;
+            background: var(--apsa-secondary);
+        }
+        .section-title {
+            position: relative;
+            margin-bottom: 3rem;
+            text-align: center;
+        }
+        .section-title:after {
+            content: '';
+            position: absolute;
+            bottom: -10px;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 60px;
+            height: 3px;
+            background: var(--apsa-secondary);
+        }
+        .btn-primary {
+            background-color: var(--apsa-secondary);
+            border-color: var(--apsa-secondary);
+        }
+        .btn-primary:hover {
+            background-color: var(--apsa-primary);
+            border-color: var(--apsa-primary);
+        }
+        @media (max-width:768px) {
+            .hero-section {
+                min-height: 60vh;
+                text-align: center;
+            }
+            .timeline-item {
+                padding-left: 40px;
+            }
+        }
+    </style>
 </head>
 <body>
-<div class="container mt-5">
-    <h1 th:text="${title}">ダッシュボード</h1>
-    <p>ユーザー数: <span th:text="${userCount}">0</span></p>
+<h1 class="mb-4" th:text="${title}">ダッシュボード</h1>
+<div class="row g-4">
+    <div class="col-12 col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title">ユーザー数</h5>
+                <p class="display-6 mb-0" th:text="${userCount}">0</p>
+            </div>
+        </div>
+    </div>
 </div>
-<script src="/webjars/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
+
+<section id="home" class="hero-section mt-4">
+    <div class="container">
+        <div class="row align-items-center">
+            <div class="col-lg-8">
+                <div class="hero-content">
+                    <h1>IT未経験から<br class="d-sm-none">3ヶ月で<br class="d-sm-none">エンジニアへ</h1>
+                    <p class="lead">体系的に学ぶ、段階的カリキュラム<br>Java Silver・基本情報技術者・Webアプリ開発まで完全サポート</p>
+                    <div class="d-flex flex-column flex-sm-row gap-3">
+                        <a href="#program" class="btn btn-primary btn-lg">
+                            <i class="fas fa-play me-2"></i>カリキュラムを見る
+                        </a>
+                        <a href="resources/faq.html" class="btn btn-outline-light btn-lg">
+                            <i class="fas fa-question-circle me-2"></i>よくある質問
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-4 d-none d-lg-block">
+                <div class="text-center">
+                    <div class="progress-chart-container">
+                        <canvas id="heroChart"></canvas>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="py-5 bg-light">
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 col-6">
+                <div class="stat-card">
+                    <div class="stat-number">3</div>
+                    <div class="stat-label">ヶ月間</div>
+                </div>
+            </div>
+            <div class="col-md-3 col-6">
+                <div class="stat-card">
+                    <div class="stat-number">54</div>
+                    <div class="stat-label">日間</div>
+                </div>
+            </div>
+            <div class="col-md-3 col-6">
+                <div class="stat-card">
+                    <div class="stat-number">12</div>
+                    <div class="stat-label">週間</div>
+                </div>
+            </div>
+            <div class="col-md-3 col-6">
+                <div class="stat-card">
+                    <div class="stat-number">100%</div>
+                    <div class="stat-label">無償教材</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="py-5">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 mx-auto">
+                <h2 class="section-title">育成目標</h2>
+                <p class="text-center lead mb-5">このカリキュラムは、IT業界未経験者を3ヶ月間で基本的なITエンジニアスキルを習得させ、実際の開発現場で活躍できる人材を育成することを目指しています。段階的な学習設計により、プログラミングの基礎から実践的なWeb開発まで、体系的に学習できる内容となっています。</p>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-lg-4 mb-4">
+                <div class="text-center">
+                    <div class="feature-icon">
+                        <i class="fas fa-graduation-cap"></i>
+                    </div>
+                    <h4>段階的学習</h4>
+                    <p>基礎から応用まで、無理のないステップで確実にスキルアップできます。</p>
+                </div>
+            </div>
+            <div class="col-lg-4 mb-4">
+                <div class="text-center">
+                    <div class="feature-icon">
+                        <i class="fas fa-certificate"></i>
+                    </div>
+                    <h4>資格取得サポート</h4>
+                    <p>Java Silver、基本情報技術者試験の合格を目指した実践的なカリキュラム。</p>
+                </div>
+            </div>
+            <div class="col-lg-4 mb-4">
+                <div class="text-center">
+                    <div class="feature-icon">
+                        <i class="fas fa-laptop-code"></i>
+                    </div>
+                    <h4>実践重視</h4>
+                    <p>理論だけでなく、実際のWebアプリケーション開発を通じて技術を習得。</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="py-5 bg-light">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-8 mx-auto text-center">
+                <h2 class="section-title">対象者</h2>
+                <div class="card">
+                    <div class="card-body p-4">
+                        <h4 class="card-title">20代～30代の未経験者</h4>
+                        <p class="card-text">Windows・Microsoft Officeの基本操作ができるレベルからスタート。IT業界への転職やキャリアチェンジを希望する方に最適です。</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section id="program" class="py-5">
+    <div class="container">
+        <div class="row">
+            <div class="col-lg-4 mb-4">
+                <div class="card month-card h-100">
+                    <div class="card-header text-center py-3">
+                        <h4 class="mb-0">第1ヶ月目</h4>
+                        <h5 class="mb-0">Java Silver</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <strong>目標:</strong> Oracle Certified Java Programmer資格取得レベルの知識習得
+                        </div>
+                        <h6>主な学習内容:</h6>
+                        <ul class="list-unstyled">
+                            <li><i class="fas fa-check text-success me-2"></i>Java言語基礎・基本構文</li>
+                            <li><i class="fas fa-check text-success me-2"></i>オブジェクト指向プログラミング</li>
+                            <li><i class="fas fa-check text-success me-2"></i>Java言語応用（コレクション、Stream API等）</li>
+                            <li><i class="fas fa-check text-success me-2"></i>Java SE 17の新機能</li>
+                        </ul>
+                    </div>
+                    <div class="card-footer text-center">
+                        <a href="month/month1.html" class="btn btn-primary">詳細を見る</a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-4 mb-4">
+                <div class="card month-card h-100">
+                    <div class="card-header text-center py-3">
+                        <h4 class="mb-0">第2ヶ月目</h4>
+                        <h5 class="mb-0">基本情報技術者</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <strong>目標:</strong> 基本情報技術者試験合格レベルのIT基礎知識習得
+                        </div>
+                        <h6>主な学習内容:</h6>
+                        <ul class="list-unstyled">
+                            <li><i class="fas fa-check text-success me-2"></i>コンピュータシステム・ハードウェア</li>
+                            <li><i class="fas fa-check text-success me-2"></i>ネットワーク・データベース</li>
+                            <li><i class="fas fa-check text-success me-2"></i>アルゴリズム・セキュリティ</li>
+                            <li><i class="fas fa-check text-success me-2"></i>プロジェクトマネジメント・経営戦略</li>
+                        </ul>
+                    </div>
+                    <div class="card-footer text-center">
+                        <a href="month/month2.html" class="btn btn-primary">詳細を見る</a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-4 mb-4">
+                <div class="card month-card h-100">
+                    <div class="card-header text-center py-3">
+                        <h4 class="mb-0">第3ヶ月目</h4>
+                        <h5 class="mb-0">Web開発</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <strong>目標:</strong> 実用的なWebアプリケーション開発スキルの習得
+                        </div>
+                        <h6>主な学習内容:</h6>
+                        <ul class="list-unstyled">
+                            <li><i class="fas fa-check text-success me-2"></i>HTML/CSS/JavaScript基礎</li>
+                            <li><i class="fas fa-check text-success me-2"></i>PostgreSQLとサーバーサイド開発</li>
+                            <li><i class="fas fa-check text-success me-2"></i>Spring Boot実践</li>
+                            <li><i class="fas fa-check text-success me-2"></i>総合開発プロジェクト</li>
+                        </ul>
+                    </div>
+                    <div class="card-footer text-center">
+                        <a href="month/month3.html" class="btn btn-primary">詳細を見る</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row mt-5">
+            <div class="col-12">
+                <div class="card bg-primary text-white">
+                    <div class="card-body p-4">
+                        <h3 class="card-title">4ヶ月目以降（応用コース・オプション）</h3>
+                        <p class="card-text">3ヶ月の基本カリキュラム修了後、以下の応用コースから選択して、さらに専門性を高めることができます。</p>
+                        <div class="row">
+                            <div class="col-md-3 col-sm-6 mb-2">
+                                <strong>フロントエンド応用:</strong><br>
+                                React、TypeScript、Next.js（3-4週間）
+                            </div>
+                            <div class="col-md-3 col-sm-6 mb-2">
+                                <strong>バックエンド応用:</strong><br>
+                                Spring応用、マイクロサービス、クラウド連携（4-5週間）
+                            </div>
+                            <div class="col-md-3 col-sm-6 mb-2">
+                                <strong>開発プロセス高度化:</strong><br>
+                                Git応用、CI/CD、コンテナ化、アジャイル開発（3-4週間）
+                            </div>
+                            <div class="col-md-3 col-sm-6 mb-2">
+                                <strong>ポートフォリオ開発:</strong><br>
+                                オリジナルプロジェクト開発、就職対策（4-6週間）
+                            </div>
+                        </div>
+                        <div class="text-center mt-3">
+                            <a href="resources/advanced.html" class="btn btn-light">応用コースの詳細</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="py-5 bg-light">
+    <div class="container">
+        <h2 class="section-title">スケジュール概要</h2>
+        <div class="row">
+            <div class="col-lg-8 mx-auto">
+                <div class="timeline">
+                    <div class="timeline-item">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <div>
+                                <h5 class="mb-1">第1週: Java基礎</h5>
+                                <p class="mb-0">Day 1-5: Javaの基本を学ぶ</p>
+                            </div>
+                            <a href="week/week1.html" class="btn btn-sm btn-outline-primary">詳細</a>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <div>
+                                <h5 class="mb-1">第2週: オブジェクト指向</h5>
+                                <p class="mb-0">Day 6-10: クラス設計とポリモーフィズム</p>
+                            </div>
+                            <a href="week/week2.html" class="btn btn-sm btn-outline-primary">詳細</a>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <div>
+                                <h5 class="mb-1">第3週: Java応用</h5>
+                                <p class="mb-0">Day 11-15: 例外処理・データベース</p>
+                            </div>
+                            <a href="week/week3.html" class="btn btn-sm btn-outline-primary">詳細</a>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <div>
+                                <h5 class="mb-1">第4週: 総仕上げ</h5>
+                                <p class="mb-0">Day 16-20: 総合演習</p>
+                            </div>
+                            <a href="week/week4.html" class="btn btn-sm btn-outline-primary">詳細</a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const ctx = document.getElementById('heroChart');
+        if (ctx) {
+            new Chart(ctx, {
+                type: 'doughnut',
+                data: {
+                    labels: ['Java Silver', '基本情報', 'Web開発'],
+                    datasets: [{
+                        data: [33, 33, 34],
+                        backgroundColor: ['#3498db', '#2c3e50', '#e74c3c'],
+                        borderWidth: 0
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: {
+                            position: 'bottom',
+                            labels: {
+                                color: 'white',
+                                padding: 20
+                            }
+                        }
+                    }
+                }
+            });
+        }
+    });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## 概要
- iframeを廃止し、dashboard.htmlにindex.htmlの静的コンテンツを直接記述
- progress_and_planning.htmlとREADMEを更新し、変更履歴と進捗を反映

## テスト
- `npm run test:e2e`（`psql` が見つからず失敗）

------
https://chatgpt.com/codex/tasks/task_b_68962d0939d483248b8681d4dc12949f