### PR TITLE
Add controllers for curriculum pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 - Java は [Amazon Corretto](https://aws.amazon.com/corretto/) を使用
 - IDE は [Pleiades](https://pleiades.io/) を推奨
 
-## 進捗状況（2025-08-08時点）
+## 進捗状況（2025-08-09時点）
 - **全体進捗:** 56%
 - **月別ページ:** 100%
 - **週別ページ:** 100%
@@ -76,6 +76,7 @@
 - フロントエンド：dashboard.htmlをindex.htmlのスタイルに合わせて更新
 - フロントエンド：dashboard.htmlをlayout.htmlを利用する構造に変更
 - フロントエンド：ダッシュボードにindex.htmlの静的コンテンツを直接埋め込み
+- バックエンド：day、week、month、lectureフォルダのHTMLを表示するコントローラーを追加
 
 ## 今後のタスク（優先順位順）
 1. `day6.html`〜`day54.html` の作成（残り49日分）

--- a/progress_and_planning.html
+++ b/progress_and_planning.html
@@ -44,6 +44,7 @@
         <div class="bg-white rounded-lg shadow-md p-6 mb-6">
             <h2 class="text-2xl font-bold text-custom-blue mb-4">プロジェクト概要</h2>
         <p class="mb-4">このプロジェクトは、IT未経験者を3ヶ月間で基礎から応用まで育成するための総合カリキュラムのWebサイト作成です。全54日分のカリキュラム内容を日別・週別・月別に整理し、体系的な学習環境を提供します。</p>
+        <p class="text-gray-600 text-sm mb-2">2025-08-09: day・week・month・lectureフォルダの全HTMLを表示するコントローラーを追加。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-08: dashboard.htmlにindex.htmlの静的コンテンツを直接埋め込み。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-07: dashboard.htmlにindex.htmlの静的コンテンツを表示。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-07: dashboard.htmlをindex.htmlのスタイルに合わせて更新。</p>

--- a/src/main/java/jp/co/apsa/giiku/controller/DayController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/DayController.java
@@ -1,0 +1,26 @@
+package jp.co.apsa.giiku.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * 日別ページを表示するコントローラー。
+ */
+@Controller
+@RequestMapping("/day")
+public class DayController {
+
+    /**
+     * 指定された日付ページを表示します。
+     *
+     * @param page ページ名 (例: day1)
+     * @return 対応するテンプレート
+     */
+    @GetMapping("/{page}")
+    public String day(@PathVariable String page) {
+        return "day/" + page;
+    }
+}
+

--- a/src/main/java/jp/co/apsa/giiku/controller/LectureController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/LectureController.java
@@ -1,0 +1,26 @@
+package jp.co.apsa.giiku.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * 講義ページを表示するコントローラー。
+ */
+@Controller
+@RequestMapping("/lecture")
+public class LectureController {
+
+    /**
+     * 指定された講義ページを表示します。
+     *
+     * @param page ページ名 (例: day1_lecture)
+     * @return 対応するテンプレート
+     */
+    @GetMapping("/{page}")
+    public String lecture(@PathVariable String page) {
+        return "lecture/" + page;
+    }
+}
+

--- a/src/main/java/jp/co/apsa/giiku/controller/MonthController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/MonthController.java
@@ -1,0 +1,26 @@
+package jp.co.apsa.giiku.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * 月別ページを表示するコントローラー。
+ */
+@Controller
+@RequestMapping("/month")
+public class MonthController {
+
+    /**
+     * 指定された月ページを表示します。
+     *
+     * @param page ページ名 (例: month1)
+     * @return 対応するテンプレート
+     */
+    @GetMapping("/{page}")
+    public String month(@PathVariable String page) {
+        return "month/" + page;
+    }
+}
+

--- a/src/main/java/jp/co/apsa/giiku/controller/WeekController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/WeekController.java
@@ -1,0 +1,26 @@
+package jp.co.apsa.giiku.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+/**
+ * 週別ページを表示するコントローラー。
+ */
+@Controller
+@RequestMapping("/week")
+public class WeekController {
+
+    /**
+     * 指定された週ページを表示します。
+     *
+     * @param page ページ名 (例: week1)
+     * @return 対応するテンプレート
+     */
+    @GetMapping("/{page}")
+    public String week(@PathVariable String page) {
+        return "week/" + page;
+    }
+}
+

--- a/src/test/java/jp/co/apsa/giiku/controller/DayControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/DayControllerTest.java
@@ -1,0 +1,37 @@
+package jp.co.apsa.giiku.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = DayController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@org.springframework.test.context.ContextConfiguration(classes = DayControllerTest.TestConfig.class)
+class DayControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @org.springframework.boot.autoconfigure.SpringBootApplication(
+        exclude = {
+            org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration.class,
+            org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration.class,
+            org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration.class
+        }
+    )
+    static class TestConfig {
+    }
+
+    @Test
+    void dayPageReturnsView() throws Exception {
+        mockMvc.perform(get("/day/day1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("day/day1"));
+    }
+}
+

--- a/src/test/java/jp/co/apsa/giiku/controller/LectureControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/LectureControllerTest.java
@@ -1,0 +1,37 @@
+package jp.co.apsa.giiku.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = LectureController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@org.springframework.test.context.ContextConfiguration(classes = LectureControllerTest.TestConfig.class)
+class LectureControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @org.springframework.boot.autoconfigure.SpringBootApplication(
+        exclude = {
+            org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration.class,
+            org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration.class,
+            org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration.class
+        }
+    )
+    static class TestConfig {
+    }
+
+    @Test
+    void lecturePageReturnsView() throws Exception {
+        mockMvc.perform(get("/lecture/day1_lecture"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("lecture/day1_lecture"));
+    }
+}
+

--- a/src/test/java/jp/co/apsa/giiku/controller/MonthControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/MonthControllerTest.java
@@ -1,0 +1,37 @@
+package jp.co.apsa.giiku.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = MonthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@org.springframework.test.context.ContextConfiguration(classes = MonthControllerTest.TestConfig.class)
+class MonthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @org.springframework.boot.autoconfigure.SpringBootApplication(
+        exclude = {
+            org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration.class,
+            org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration.class,
+            org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration.class
+        }
+    )
+    static class TestConfig {
+    }
+
+    @Test
+    void monthPageReturnsView() throws Exception {
+        mockMvc.perform(get("/month/month1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("month/month1"));
+    }
+}
+

--- a/src/test/java/jp/co/apsa/giiku/controller/WeekControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/WeekControllerTest.java
@@ -1,0 +1,37 @@
+package jp.co.apsa.giiku.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = WeekController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@org.springframework.test.context.ContextConfiguration(classes = WeekControllerTest.TestConfig.class)
+class WeekControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @org.springframework.boot.autoconfigure.SpringBootApplication(
+        exclude = {
+            org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration.class,
+            org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration.class,
+            org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration.class
+        }
+    )
+    static class TestConfig {
+    }
+
+    @Test
+    void weekPageReturnsView() throws Exception {
+        mockMvc.perform(get("/week/week1"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("week/week1"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- serve day, week, month, and lecture HTML via dedicated controllers
- cover new controllers with MVC tests
- document controller addition in README and progress log

## Testing
- `./gradlew test`
- `npx playwright test` *(fails: connection refused to PostgreSQL server)*

------
https://chatgpt.com/codex/tasks/task_b_6896a20f30c083248df19359beb10a6e