### PR TITLE
Add standard Javadoc tags to all classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,8 @@
 - Codex は質問への回答を原則日本語で行う。
 - Java 実行環境は Amazon Corretto を利用する。
 - 推奨 IDE は Pleiades (Eclipse) とする。
+
+- すべてのJavaクラスには以下のJavadocタグを含めること:
+  - @author 株式会社アプサ
+  - @version 1.0
+  - @since 2025

--- a/src/main/java/jp/co/apsa/giiku/controller/DayController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/DayController.java
@@ -7,6 +7,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
  * 日別ページを表示するコントローラー。
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 @Controller
 @RequestMapping("/day")

--- a/src/main/java/jp/co/apsa/giiku/controller/LectureController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/LectureController.java
@@ -7,6 +7,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
  * 講義ページを表示するコントローラー。
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 @Controller
 @RequestMapping("/lecture")

--- a/src/main/java/jp/co/apsa/giiku/controller/MonthController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/MonthController.java
@@ -7,6 +7,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
  * 月別ページを表示するコントローラー。
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 @Controller
 @RequestMapping("/month")

--- a/src/main/java/jp/co/apsa/giiku/controller/WeekController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/WeekController.java
@@ -7,6 +7,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 /**
  * 週別ページを表示するコントローラー。
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 @Controller
 @RequestMapping("/week")

--- a/src/main/java/jp/co/apsa/giiku/domain/entity/Company.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/entity/Company.java
@@ -17,6 +17,9 @@ import java.time.LocalDateTime;
 
 /**
  * 会社エンティティクラス。
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 @Entity
 @Table(name = "companies")

--- a/src/main/java/jp/co/apsa/giiku/domain/entity/User.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/entity/User.java
@@ -19,6 +19,9 @@ import java.time.LocalDateTime;
 
 /**
  * ユーザーエンティティクラス。
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 @Entity
 @Table(name = "users")

--- a/src/main/java/jp/co/apsa/giiku/domain/port/AuditPort.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/port/AuditPort.java
@@ -4,6 +4,9 @@ import jp.co.apsa.giiku.domain.valueobject.LogLevel;
 
 /**
  * Port for application logging.
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 public interface AuditPort {
 

--- a/src/main/java/jp/co/apsa/giiku/domain/port/NotificationPort.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/port/NotificationPort.java
@@ -7,6 +7,9 @@ import java.util.concurrent.CompletableFuture;
  *
  * <p>Allows the application layer to send notifications without
  * depending on concrete infrastructure such as Slack.</p>
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 public interface NotificationPort {
 

--- a/src/main/java/jp/co/apsa/giiku/domain/repository/CompanyRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/CompanyRepository.java
@@ -10,6 +10,9 @@ import java.util.Optional;
 
 /**
  * 会社リポジトリインターフェース。
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 @Repository
 @Validated

--- a/src/main/java/jp/co/apsa/giiku/infrastructure/audit/LoggingService.java
+++ b/src/main/java/jp/co/apsa/giiku/infrastructure/audit/LoggingService.java
@@ -10,6 +10,9 @@ import org.springframework.stereotype.Service;
 
 /**
  * Simple implementation of {@link AuditPort} that delegates to SLF4J.
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 @Service
 public class LoggingService implements AuditPort {

--- a/src/main/java/jp/co/apsa/giiku/infrastructure/notification/SlackNotificationService.java
+++ b/src/main/java/jp/co/apsa/giiku/infrastructure/notification/SlackNotificationService.java
@@ -20,6 +20,9 @@ import jp.co.apsa.giiku.domain.port.NotificationPort;
 
 /**
  * Slack Webhook を利用した通知サービスの簡易実装。
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 @Service
 public class SlackNotificationService implements NotificationPort {

--- a/src/test/java/jp/co/apsa/giiku/application/service/DashboardServiceTest.java
+++ b/src/test/java/jp/co/apsa/giiku/application/service/DashboardServiceTest.java
@@ -7,6 +7,11 @@ import jp.co.apsa.giiku.domain.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+/**
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
 class DashboardServiceTest {
 
     @Test

--- a/src/test/java/jp/co/apsa/giiku/controller/AbstractControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/AbstractControllerTest.java
@@ -6,6 +6,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.ui.ConcurrentModel;
 import org.springframework.ui.Model;
 
+/**
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
 class AbstractControllerTest {
 
     private static class TestController extends AbstractController {

--- a/src/test/java/jp/co/apsa/giiku/controller/DashboardControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/DashboardControllerTest.java
@@ -12,6 +12,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
 @WebMvcTest(controllers = DashboardController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @org.springframework.test.context.ContextConfiguration(classes = DashboardControllerTest.TestConfig.class)

--- a/src/test/java/jp/co/apsa/giiku/controller/DayControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/DayControllerTest.java
@@ -9,6 +9,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
 @WebMvcTest(controllers = DayController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @org.springframework.test.context.ContextConfiguration(classes = DayControllerTest.TestConfig.class)

--- a/src/test/java/jp/co/apsa/giiku/controller/LectureControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/LectureControllerTest.java
@@ -9,6 +9,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
 @WebMvcTest(controllers = LectureController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @org.springframework.test.context.ContextConfiguration(classes = LectureControllerTest.TestConfig.class)

--- a/src/test/java/jp/co/apsa/giiku/controller/LoginControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/LoginControllerTest.java
@@ -11,6 +11,11 @@ import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.DefaultCsrfToken;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
 @WebMvcTest(controllers = LoginController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @org.springframework.test.context.ContextConfiguration(classes = LoginControllerTest.TestConfig.class)

--- a/src/test/java/jp/co/apsa/giiku/controller/MonthControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/MonthControllerTest.java
@@ -9,6 +9,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
 @WebMvcTest(controllers = MonthController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @org.springframework.test.context.ContextConfiguration(classes = MonthControllerTest.TestConfig.class)

--- a/src/test/java/jp/co/apsa/giiku/controller/WeekControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/WeekControllerTest.java
@@ -9,6 +9,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
 @WebMvcTest(controllers = WeekController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @org.springframework.test.context.ContextConfiguration(classes = WeekControllerTest.TestConfig.class)

--- a/src/test/java/jp/co/apsa/giiku/domain/valueobject/LogLevelTest.java
+++ b/src/test/java/jp/co/apsa/giiku/domain/valueobject/LogLevelTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Test;
 
 /**
  * {@link LogLevel} のユニットテスト。
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 class LogLevelTest {
 

--- a/src/test/java/jp/co/apsa/giiku/domain/valueobject/SlackIdTest.java
+++ b/src/test/java/jp/co/apsa/giiku/domain/valueobject/SlackIdTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.Test;
 
 /**
  * {@link SlackId} のユニットテスト。
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 class SlackIdTest {
 


### PR DESCRIPTION
## Summary
- ensure every Java class includes Javadoc tags for author, version, and since
- document this Javadoc requirement in AGENTS.md

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_6896a7a8ceb8832480e3fecd063c14f7