### PR TITLE
layoutにweek1のヘッダーとフッターを反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@
 - フロントエンド：ダッシュボードにindex.htmlの静的コンテンツを直接埋め込み
 - バックエンド：day、week、month、lectureフォルダのHTMLを表示するコントローラーを追加
 - dayX_lecture.htmlの回答ボタンと内容をADMIN/INSTRUCTORのみ表示に変更（静的HTMLでは全表示）
+- フロントエンド：layout.htmlにweek1.htmlのヘッダーとフッターを適用
 
 ## 今後のタスク（優先順位順）
 1. `day6.html`〜`day54.html` の作成（残り49日分）

--- a/progress_and_planning.html
+++ b/progress_and_planning.html
@@ -44,6 +44,7 @@
         <div class="bg-white rounded-lg shadow-md p-6 mb-6">
             <h2 class="text-2xl font-bold text-custom-blue mb-4">プロジェクト概要</h2>
         <p class="mb-4">このプロジェクトは、IT未経験者を3ヶ月間で基礎から応用まで育成するための総合カリキュラムのWebサイト作成です。全54日分のカリキュラム内容を日別・週別・月別に整理し、体系的な学習環境を提供します。</p>
+        <p class="text-gray-600 text-sm mb-2">2025-08-09: layout.htmlにweek1.htmlのヘッダーとフッターを適用。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-09: day・week・month・lectureフォルダの全HTMLを表示するコントローラーを追加。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-08: dashboard.htmlにindex.htmlの静的コンテンツを直接埋め込み。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-07: dashboard.htmlにindex.htmlの静的コンテンツを表示。</p>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -11,63 +11,77 @@
     <link th:href="@{/css/giiku-style.css}" rel="stylesheet">
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-dark navbar-custom">
-    <div class="container-fluid">
-        <a class="navbar-brand d-flex align-items-center" th:href="@{/}">
-            <img th:src="@{/images/giiku_logo.png}" alt="Giiku" width="32" height="32" class="me-2">
-        </a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMenu" aria-controls="navMenu" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navMenu">
-            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                <li class="nav-item"><a class="nav-link" th:href="@{/dashboard}">ダッシュボード</a></li>
-                <li class="nav-item" sec:authorize="hasRole('ADMIN')">
-                    <a class="nav-link" th:href="@{/admin}">マスタメンテナンス</a>
-                </li>
-                <li class="nav-item dropdown" sec:authorize="hasAnyRole('ADMIN','MANAGER')">
-                    <a class="nav-link dropdown-toggle" href="#" id="adminMenu" role="button" data-bs-toggle="dropdown" aria-expanded="false">管理</a>
-                    <ul class="dropdown-menu" aria-labelledby="adminMenu">
-                        <li><a class="dropdown-item" th:href="@{/approvals}">承認一覧</a></li>
-                        <li><a class="dropdown-item" th:href="@{/admin/requests}">申請一覧</a></li>
-                    </ul>
-                </li>
-                <li class="nav-item dropdown" sec:authorize="hasAnyRole('ADMIN','MANAGER','USER')">
-                    <a class="nav-link dropdown-toggle" href="#" id="applyMenu" role="button" data-bs-toggle="dropdown" aria-expanded="false">申請</a>
-                    <ul class="dropdown-menu" aria-labelledby="applyMenu">
-                        <li th:each="type : ${activeApplicationTypes}">
-                            <a class="dropdown-item" th:text="${type.name}"
-                               th:href="@{'/' + ${type.code.toLowerCase()} + '/apply'}"></a>
-                        </li>
-                    </ul>
-                </li>
-            </ul>
-            <ul class="navbar-nav ms-auto">
-                <li class="nav-item"><span class="nav-link" th:text="${currentUserDisplayName}">User</span></li>
-                <li class="nav-item"><a class="nav-link" th:href="@{/logout}">ログアウト</a></li>
-            </ul>
+    <nav class="navbar navbar-expand-lg navbar-dark">
+        <div class="container">
+            <a class="navbar-brand" href="index.html">
+                <img src="images/logo/apsa_logo.png" alt="APSA Logo">
+                <span class="ms-2">ITエンジニア育成カリキュラム</span>
+            </a>
+            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarNav">
+                <ul class="navbar-nav ms-auto">
+                    <li class="nav-item">
+                        <a class="nav-link" href="index.html">ホーム</a>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="monthDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            月別カリキュラム
+                        </a>
+                        <ul class="dropdown-menu" aria-labelledby="monthDropdown">
+                            <li><a class="dropdown-item" href="month/month1.html">第1ヶ月目: Java Silver</a></li>
+                            <li><a class="dropdown-item" href="month/month2.html">第2ヶ月目: 基本情報</a></li>
+                            <li><a class="dropdown-item" href="month/month3.html">第3ヶ月目: Web開発</a></li>
+                        </ul>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="weekDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            週別詳細
+                        </a>
+                        <ul class="dropdown-menu" aria-labelledby="weekDropdown">
+                            <li><a class="dropdown-item" href="week/week1.html">第1週: Java基礎</a></li>
+                            <li><a class="dropdown-item" href="week/week2.html">第2週: オブジェクト指向</a></li>
+                            <li><a class="dropdown-item" href="week/week3.html">第3週: Java応用</a></li>
+                            <li><a class="dropdown-item" href="week/week4.html">第4週: 総仕上げ</a></li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li><a class="dropdown-item" href="week/week5.html">第5週: コンピュータシステム</a></li>
+                            <li><a class="dropdown-item" href="week/week6.html">第6週: ネットワーク・DB</a></li>
+                            <li><a class="dropdown-item" href="week/week7.html">第7週: アルゴリズム・セキュリティ</a></li>
+                            <li><a class="dropdown-item" href="week/week8.html">第8週: ストラテジ系</a></li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li><a class="dropdown-item" href="week/week9.html">第9週: フロントエンド基礎</a></li>
+                            <li><a class="dropdown-item" href="week/week10.html">第10週: バックエンド基礎</a></li>
+                            <li><a class="dropdown-item" href="week/week11.html">第11週: Spring Boot実践</a></li>
+                            <li><a class="dropdown-item" href="week/week12.html">第12週: 総合開発</a></li>
+                        </ul>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="dayDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            日別カリキュラム
+                        </a>
+                        <ul class="dropdown-menu" aria-labelledby="dayDropdown">
+                            <li><a class="dropdown-item" href="day/day1.html">Day 1: オリエンテーシン</a></li>
+                            <li><a class="dropdown-item" href="day/day2.html">Day 2: Java基本型・変数・演算子</a></li>
+                            <li><a class="dropdown-item" href="day/day3.html">Day 3: 制御構文・配列</a></li>
+                            <li><a class="dropdown-item" href="day/day4.html">Day 4: 配列応用・アルゴリズム基礎</a></li>
+                            <li><a class="dropdown-item" href="day/day5.html">Day 5: Java Silver模擬テスト①</a></li>
+                        </ul>
+                    </li>
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle" href="#" id="resourceDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                            リソース
+                        </a>
+                        <ul class="dropdown-menu" aria-labelledby="resourceDropdown">
+                            <li><a class="dropdown-item" href="resources/resources.html">学習リソース</a></li>
+                            <li><a class="dropdown-item" href="resources/faq.html">よくある質問</a></li>
+                            <li><a class="dropdown-item" href="resources/advanced.html">応用コース</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
         </div>
-    </div>
-</nav>
-<nav class="navbar navbar-dark navbar-custom navbar-bottom d-md-none fixed-bottom">
-    <div class="container-fluid justify-content-around">
-        <a class="nav-link text-center" th:href="@{/dashboard}">
-            <i class="bi bi-house-fill"></i><br>ホーム
-        </a>
-        <a class="nav-link text-center" sec:authorize="hasRole('ADMIN')" th:href="@{/admin}">
-            <i class="bi bi-gear-fill"></i><br>マスタ
-        </a>
-        <a class="nav-link text-center" sec:authorize="hasAnyRole('ADMIN','MANAGER','USER')" th:href="@{/dashboard}">
-            <i class="bi bi-pencil-square"></i><br>申請
-        </a>
-        <a class="nav-link text-center" sec:authorize="hasAnyRole('ADMIN','MANAGER')" th:href="@{/approvals}">
-            <i class="bi bi-check2-square"></i><br>承認
-        </a>
-        <a class="nav-link text-center" th:href="@{/logout}">
-            <i class="bi bi-box-arrow-right"></i><br>退出
-        </a>
-    </div>
-</nav>
+    </nav>
 <div class="container mt-4">
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb">
@@ -78,9 +92,45 @@
     </nav>
     <div th:replace="${content}"></div>
 </div>
-<footer class="site-footer text-center py-3 mt-auto">
+<footer>
     <div class="container">
-        <small>&copy; 2025 APSA Co.,Ltd.</small>
+        <div class="row">
+            <div class="col-lg-3 mb-4">
+                <div class="footer-logo">
+                    <img src="images/logo/apsa_logo.png" alt="APSA Logo" class="mb-3">
+                    <p>ITエンジニア育成カリキュラム</p>
+                </div>
+            </div>
+            <div class="col-lg-3 col-md-6 mb-4">
+                <h5>カリキュラム</h5>
+                <ul class="list-unstyled">
+                    <li><a href="month/month1.html">第1ヶ月目: Java Silver</a></li>
+                    <li><a href="month/month2.html">第2ヶ月目: 基本情報</a></li>
+                    <li><a href="month/month3.html">第3ヶ月目: Web開発</a></li>
+                </ul>
+            </div>
+            <div class="col-lg-3 col-md-6 mb-4">
+                <h5>リソース</h5>
+                <ul class="list-unstyled">
+                    <li><a href="resources/resources.html">学習リソース</a></li>
+                    <li><a href="resources/faq.html">よくある質問</a></li>
+                    <li><a href="resources/advanced.html">応用コース</a></li>
+                </ul>
+            </div>
+            <div class="col-lg-3 col-md-6 mb-4">
+                <h5>その他</h5>
+                <ul class="list-unstyled">
+                    <li><a href="index.html">ホームページ</a></li>
+                    <li><a href="https://www.apsa.co.jp/" target="_blank">APSA公式サイト</a></li>
+                    <li><a href="mailto:info@example.com">お問い合わせ</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="row mt-4">
+            <div class="col-12 text-center">
+                <p class="mb-0">&copy; 2025 APSA Co.,Ltd. All Rights Reserved.</p>
+            </div>
+        </div>
     </div>
 </footer>
 


### PR DESCRIPTION
## Summary
- layout.htmlにweek1.htmlと同じナビゲーションとフッターを追加
- 進捗記録とREADMEに変更内容を追記

## Testing
- `xdg-open src/main/resources/templates/index.html` (command not found)


------
https://chatgpt.com/codex/tasks/task_b_6896caaac01c83248ed163f6094dbfb1