### PR TITLE
Adjust navigation bar colors

### DIFF
--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -11,7 +11,7 @@
     <link th:href="@{/css/giiku-style.css}" rel="stylesheet">
 </head>
 <body>
-    <nav class="navbar navbar-expand-lg navbar-dark" style="background-color: #1a4f8e;">
+    <nav class="navbar navbar-expand-lg navbar-light" style="background-color: #e3f2fd; --bs-navbar-color: #0d47a1; --bs-navbar-hover-color: #0a3575; --bs-navbar-active-color: #0a3575; --bs-navbar-brand-color: #0d47a1; --bs-navbar-brand-hover-color: #0a3575;">
         <div class="container">
             <a class="navbar-brand" href="index.html">
                 <img src="../static/images/logo/giiku_logo_horizontal.png" th:src="@{images/logo/giiku_logo_horizontal.png}" alt="Giiku Logo" height="30px">


### PR DESCRIPTION
## Summary
- Adjust navigation bar to use dark blue text on light blue background for improved contrast

## Testing
- `./gradlew build` *(fails: cannot open browser to manually verify layout)*

------
https://chatgpt.com/codex/tasks/task_b_68973cdfa560832486331192c4f5bdff