### PR TITLE
Fix login redirect after session timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@
 - dayX_lecture.htmlの回答ボタンと内容をADMIN/INSTRUCTORのみ表示に変更（静的HTMLでは全表示）
 - フロントエンド：layout.htmlにweek1.htmlのヘッダーとフッターを適用
 - フロントエンド：layout.htmlのナビゲーション配色をロゴの青に合わせて改善
+- バックエンド：セッション切れ後のログインエラーを修正
 
 ## 今後のタスク（優先順位順）
 1. `day6.html`〜`day54.html` の作成（残り49日分）

--- a/progress_and_planning.html
+++ b/progress_and_planning.html
@@ -44,6 +44,7 @@
         <div class="bg-white rounded-lg shadow-md p-6 mb-6">
             <h2 class="text-2xl font-bold text-custom-blue mb-4">プロジェクト概要</h2>
         <p class="mb-4">このプロジェクトは、IT未経験者を3ヶ月間で基礎から応用まで育成するための総合カリキュラムのWebサイト作成です。全54日分のカリキュラム内容を日別・週別・月別に整理し、体系的な学習環境を提供します。</p>
+        <p class="text-gray-600 text-sm mb-2">2025-08-09: セッション切れ後のログインエラーを修正。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-09: layout.htmlのナビゲーション配色をロゴの青に合わせて改善。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-09: layout.htmlにweek1.htmlのヘッダーとフッターを適用。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-09: day・week・month・lectureフォルダの全HTMLを表示するコントローラーを追加。</p>

--- a/src/main/java/jp/co/apsa/giiku/config/SecurityConfig.java
+++ b/src/main/java/jp/co/apsa/giiku/config/SecurityConfig.java
@@ -54,7 +54,8 @@ public class SecurityConfig {
                 .requestMatchers(
                     new AntPathRequestMatcher("/login"),
                     new AntPathRequestMatcher("/login-error"),
-                    new AntPathRequestMatcher("/logout")
+                    new AntPathRequestMatcher("/logout"),
+                    new AntPathRequestMatcher("/error")
                 ).permitAll()
 
                 // 管理者機能は管理者権限必要
@@ -70,7 +71,7 @@ public class SecurityConfig {
                 .loginProcessingUrl("/login-process")   // ログイン処理URL
                 .usernameParameter("username")          // ユーザー名パラメータ
                 .passwordParameter("password")          // パスワードパラメータ
-                .defaultSuccessUrl("/dashboard")       // ログイン成功時のリダイレクト先
+                .defaultSuccessUrl("/dashboard", true)       // ログイン成功時のリダイレクト先
                 .failureUrl("/login-error")             // ログイン失敗時のリダイレクト先
                 .permitAll()
             )


### PR DESCRIPTION
## Summary
- always redirect to dashboard after login and permit access to error page
- document session timeout login fix in progress log and README

## Testing
- `./gradlew build`
- `xdg-open index.html` *(command not found: xdg-open)*

------
https://chatgpt.com/codex/tasks/task_b_68973ea289b08324a0e292579232136c