### PR TITLE
fix: align logo with navbar

### DIFF
--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -14,7 +14,7 @@
     <nav class="navbar navbar-expand-lg navbar-light" style="background-color: #e3f2fd; --bs-navbar-color: #0d47a1; --bs-navbar-hover-color: #0a3575; --bs-navbar-active-color: #0a3575; --bs-navbar-brand-color: #0d47a1; --bs-navbar-brand-hover-color: #0a3575;">
         <div class="container">
             <a class="navbar-brand" href="index.html">
-                <img src="../static/images/logo/giiku_logo_horizontal.png" th:src="@{images/logo/giiku_logo_horizontal.png}" alt="Giiku Logo" height="30px">
+                <img src="../static/images/logo/giiku_logo_horizontal.png" th:src="@{images/logo/giiku_logo_horizontal.png}" alt="Giiku Logo" height="30px" class="d-inline-block align-text-top">
                 <span class="ms-2">ITエンジニア育成カリキュラム</span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
## Summary
- align Giiku horizontal logo with navigation by applying `align-text-top`

## Testing
- `npm run test:e2e` *(fails: connection to Postgres at localhost:5432 refused)*

------
https://chatgpt.com/codex/tasks/task_b_68973f6705948324a974c77a1c0c08e8