### PR TITLE
fix: unify footer colors with header

### DIFF
--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -9,6 +9,15 @@
     <link href="../css/lib/bootstrap-icons.css" th:href="@{/webjars/bootstrap-icons/font/bootstrap-icons.css}" rel="stylesheet">
     <link href="/webjars/fortawesome__fontawesome-free/css/all.min.css" rel="stylesheet">
     <link th:href="@{/css/giiku-style.css}" rel="stylesheet">
+    <style>
+        footer {
+            background-color: #e3f2fd;
+            color: #0d47a1;
+        }
+        footer a {
+            color: #0d47a1;
+        }
+    </style>
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-light" style="background-color: #e3f2fd; --bs-navbar-color: #0d47a1; --bs-navbar-hover-color: #0a3575; --bs-navbar-active-color: #0a3575; --bs-navbar-brand-color: #0d47a1; --bs-navbar-brand-hover-color: #0a3575;">


### PR DESCRIPTION
## Summary
- match footer background and text colors to header theme

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_b_689743985e988324a5208a154decd8d9