### PR TITLE
fix: 共通ヘッダーを固定表示に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
 - フロントエンド：dashboard.htmlをindex.htmlのスタイルに合わせて更新
 - フロントエンド：dashboard.htmlをlayout.htmlを利用する構造に変更
 - フロントエンド：ダッシュボードにindex.htmlの静的コンテンツを直接埋め込み
+- フロントエンド：共通ヘッダーを画面上部に固定
 - バックエンド：day、week、month、lectureフォルダのHTMLを表示するコントローラーを追加
 - dayX_lecture.htmlの回答ボタンと内容をADMIN/INSTRUCTORのみ表示に変更（静的HTMLでは全表示）
 - テンプレート導入に伴い消失したサンプルページのコンテンツを復元し、既存ナビゲーションと見た目を維持するルールを追加

--- a/progress_and_planning.html
+++ b/progress_and_planning.html
@@ -47,6 +47,7 @@
         <p class="text-gray-600 text-sm mb-2">2025-08-10: テンプレート構成を整理し、Thymeleafレイアウトとサンプルページを追加。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-10: サンプルページのコンテンツを復元し、レイアウト適用時は既存ナビゲーションと見た目を保持するルールを明文化。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-09: セッション切れ後のログインエラーを修正。</p>
+        <p class="text-gray-600 text-sm mb-2">2025-08-10: 共通ヘッダーを画面上部に固定。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-09: layout.htmlのナビゲーション配色をロゴの青に合わせて改善。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-09: layout.htmlにweek1.htmlのヘッダーとフッターを適用。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-09: day・week・month・lectureフォルダの全HTMLを表示するコントローラーを追加。</p>

--- a/src/main/resources/templates/_fragments/headers.html
+++ b/src/main/resources/templates/_fragments/headers.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <body>
 <!-- グローバルヘッダー -->
-<nav th:fragment="global()" class="navbar navbar-expand-lg navbar-light" style="background-color: #e3f2fd; --bs-navbar-color: #0d47a1; --bs-navbar-hover-color: #0a3575; --bs-navbar-active-color: #0a3575; --bs-navbar-brand-color: #0d47a1; --bs-navbar-brand-hover-color: #0a3575;">
+<nav th:fragment="global()" class="navbar navbar-expand-lg navbar-light sticky-top" style="background-color: #e3f2fd; --bs-navbar-color: #0d47a1; --bs-navbar-hover-color: #0a3575; --bs-navbar-active-color: #0a3575; --bs-navbar-brand-color: #0d47a1; --bs-navbar-brand-hover-color: #0a3575;">
     <div class="container">
         <a class="navbar-brand" th:href="@{/}">
             <img th:src="@{/images/logo/giiku_logo_horizontal.png}" alt="Giiku Logo" height="30px" class="d-inline-block align-text-top" style="vertical-align: middle;margin-top: -8px;">


### PR DESCRIPTION
## Summary
- グローバルヘッダーを`sticky-top`クラスで固定
- 進捗ドキュメントとREADMEにヘッダー固定の更新を記載

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_68981bc632d0832497a19c2cd5c1bf40