### PR TITLE
chore: Node Gradleプラグインの導入とNode自動ダウンロード設定

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
     id 'jacoco'
     id 'eclipse'
     id 'idea'
+    id 'com.github.node-gradle.node' version '7.0.1'
 }
 
 group = 'jp.co.apsa'
@@ -26,6 +27,10 @@ configurations {
 
 repositories {
     mavenCentral()
+}
+
+node {
+    download = true
 }
 
 dependencies {
@@ -201,15 +206,9 @@ bootRun {
 }
 
 // Tailwind CSS Build
-tasks.register('npmInstall', Exec) {
-    workingDir projectDir
-    commandLine 'npm', 'install'
-}
-
-tasks.register('buildTailwind', Exec) {
-    dependsOn 'npmInstall'
-    workingDir projectDir
-    commandLine 'npm', 'run', 'build:css'
+tasks.register('buildTailwind', com.github.gradle.node.npm.task.NpmTask) {
+    dependsOn npmInstall
+    args = ['run', 'build:css']
 }
 
 processResources.dependsOn 'buildTailwind'


### PR DESCRIPTION
## Summary
- add com.github.node-gradle.node plugin
- configure `node { download = true }`
- use plugin's npm task for Tailwind build

## Testing
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_b_689871000e5c8324871d60f17f80d884