### PR TITLE
fix: restore header navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@
 - バックエンド：セッション切れ後のログインエラーを修正
 - テンプレート構成を整理し、Thymeleafレイアウトとサンプルページ（month1、week1、day1、lecture1、admin/index）を追加
 - フロントエンド：Tailwind CSSをnpmとGradleで自動ビルドし、tailwind.min.cssを生成
+- ヘッダーナビゲーションが表示されない問題を修正
 
 ## 今後のタスク（優先順位順）
 1. `day6.html`〜`day54.html` の作成（残り49日分）

--- a/progress_and_planning.html
+++ b/progress_and_planning.html
@@ -47,6 +47,7 @@
         <p class="text-gray-600 text-sm mb-2">2025-08-10: Tailwind CSSをnpmとGradleで自動ビルドし、tailwind.min.cssを生成。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-10: テンプレート構成を整理し、Thymeleafレイアウトとサンプルページを追加。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-10: サンプルページのコンテンツを復元し、レイアウト適用時は既存ナビゲーションと見た目を保持するルールを明文化。</p>
+        <p class="text-gray-600 text-sm mb-2">2025-08-10: ヘッダーナビゲーションが表示されない問題を修正。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-09: セッション切れ後のログインエラーを修正。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-10: 共通ヘッダーを画面上部に固定。</p>
         <p class="text-gray-600 text-sm mb-2">2025-08-09: layout.htmlのナビゲーション配色をロゴの青に合わせて改善。</p>

--- a/src/main/resources/templates/_fragments/headers.html
+++ b/src/main/resources/templates/_fragments/headers.html
@@ -1,8 +1,5 @@
-<!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org">
-<body>
 <!-- グローバルヘッダー -->
-<nav th:fragment="global()" class="navbar navbar-expand-lg navbar-light sticky-top" style="background-color: #e3f2fd; --bs-navbar-color: #0d47a1; --bs-navbar-hover-color: #0a3575; --bs-navbar-active-color: #0a3575; --bs-navbar-brand-color: #0d47a1; --bs-navbar-brand-hover-color: #0a3575;">
+<nav th:fragment="global" class="navbar navbar-expand-lg navbar-light sticky-top" style="background-color: #e3f2fd; --bs-navbar-color: #0d47a1; --bs-navbar-hover-color: #0a3575; --bs-navbar-active-color: #0a3575; --bs-navbar-brand-color: #0d47a1; --bs-navbar-brand-hover-color: #0a3575;">
     <div class="container">
         <a class="navbar-brand" th:href="@{/}">
             <img th:src="@{/images/logo/giiku_logo_horizontal.png}" alt="Giiku Logo" class="d-inline-block align-text-top" style="vertical-align: middle;margin-top: -8px;height: 30px;">
@@ -92,7 +89,7 @@
 </div>
 
 <!-- フッター -->
-<footer th:fragment="footer()" style="background-color: #e3f2fd; color: #0d47a1;">
+<footer th:fragment="footer" style="background-color: #e3f2fd; color: #0d47a1;">
     <div class="container">
         <div class="row">
             <div class="col-lg-3 mb-2 mt-1">
@@ -133,5 +130,3 @@
         </div>
     </div>
 </footer>
-</body>
-</html>

--- a/src/main/resources/templates/_layouts/base.html
+++ b/src/main/resources/templates/_layouts/base.html
@@ -14,11 +14,11 @@
     <link th:href="@{/css/giiku-style.css}" rel="stylesheet">
 </head>
 <body>
-    <div th:replace="~{_fragments/headers :: global()}"></div>
+    <div th:replace="~{_fragments/headers :: global}"></div>
     <section id="sub-header" layout:fragment="subheader"></section>
     <section id="page-header" layout:fragment="pageheader"></section>
     <main class="container mt-2" layout:fragment="content"></main>
-    <div th:replace="~{_fragments/headers :: footer()}"></div>
+    <div th:replace="~{_fragments/headers :: footer}"></div>
     <link href="/webjars/fortawesome__fontawesome-free/css/all.min.css" rel="stylesheet">
     <script src="/webjars/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/webjars/chart.js/dist/chart.umd.js"></script>


### PR DESCRIPTION
## Summary
- remove outer HTML wrappers from header fragment and rename fragments
- update base layout to use new `global` and `footer` fragments
- document header fix in README and progress notes

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_b_689877d4f25c8324b2a800ce6ccf2285