### PR TITLE
weekページからTailwind CSSを削除しBootstrapへ差し替え

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - This project has no automated tests. After editing HTML or CSS, manually open `index.html` in a browser to verify that navigation and layout work correctly.
 - Document major updates or milestones in `作業進捗と計画.html` as well.
 - Keep the monthly plan in this README consistent with any curriculum updates.
+- CSS や JS ライブラリは WebJar を利用し、Thymeleaf の `th:` 属性で読み込む。
 
 - すべての Web ページはスマートフォンでも閲覧しやすいレスポンシブデザインとする。
 

--- a/src/main/resources/templates/_layouts/base.html
+++ b/src/main/resources/templates/_layouts/base.html
@@ -6,10 +6,9 @@
     <title layout:title-pattern="$CONTENT_TITLE - ITエンジニア育成カリキュラム">ITエンジニア育成カリキュラム</title>
     <meta name="_csrf" th:content="${_csrf?.token}">
     <script src="../static/js/lib/jquery.min.js" th:src="@{/js/lib/jquery.min.js}"></script>
-<!--    <script src="../static/js/lib/bootstrap.bundle.min.js" th:src="@{/js/lib/bootstrap.bundle.min.js}"></script>-->
-    <script src="../static/js/lib/chart.umd.min.js" th:src="@{/js/lib/chart.umd.min.js}"></script>
-    <link href="../static/css/lib/bootstrap.min.css" th:href="@{/css/lib/bootstrap.min.css}" rel="stylesheet">
-<!--    <link th:href="@{/webjars/bootstrap-icons/font/bootstrap-icons.css}" rel="stylesheet">-->
+    <link href="../static/css/lib/bootstrap.min.css" th:href="@{/webjars/bootstrap/dist/css/bootstrap.min.css}" rel="stylesheet">
+    <link href="../static/css/lib/bootstrap-icons.css" th:href="@{/webjars/bootstrap-icons/font/bootstrap-icons.css}" rel="stylesheet">
+    <link href="/webjars/fortawesome__fontawesome-free/css/all.min.css" th:href="@{/webjars/fortawesome__fontawesome-free/css/all.min.css}" rel="stylesheet">
     <link th:href="@{/css/giiku-style.css}" rel="stylesheet">
 </head>
 <body>
@@ -18,12 +17,11 @@
     <section id="page-header" layout:fragment="pageheader"></section>
     <main class="container mt-2" layout:fragment="content"></main>
     <div th:replace="~{_fragments/headers :: footer}"></div>
-    <link href="/webjars/fortawesome__fontawesome-free/css/all.min.css" rel="stylesheet">
-    <script src="/webjars/bootstrap/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="/webjars/chart.js/dist/chart.umd.js"></script>
-    <script src="/webjars/react/umd/react.development.js"></script>
-    <script src="/webjars/react-dom/umd/react-dom.development.js"></script>
-    <script src="/webjars/babel__standalone/babel.min.js"></script>
+    <script src="/webjars/bootstrap/dist/js/bootstrap.bundle.min.js" th:src="@{/webjars/bootstrap/dist/js/bootstrap.bundle.min.js}"></script>
+    <script src="/webjars/chart.js/dist/chart.umd.js" th:src="@{/webjars/chart.js/dist/chart.umd.js}"></script>
+    <script src="/webjars/react/umd/react.development.js" th:src="@{/webjars/react/umd/react.development.js}"></script>
+    <script src="/webjars/react-dom/umd/react-dom.development.js" th:src="@{/webjars/react-dom/umd/react-dom.development.js}"></script>
+    <script src="/webjars/babel__standalone/babel.min.js" th:src="@{/webjars/babel__standalone/babel.min.js}"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             var dropdownElementList = [].slice.call(document.querySelectorAll('.dropdown-toggle'));

--- a/src/main/resources/templates/month/month2.html
+++ b/src/main/resources/templates/month/month2.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{_layouts/month}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>第2ヶ月目: 基本情報技術者試験対策 | ITエンジニア育成カリキュラム</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
     <style>
         :root {
             --primary-color: #0d6efd;
@@ -225,6 +223,8 @@
     </style>
 </head>
 <body>
+<div layout:fragment="pageheader" th:replace="~{_fragments/headers :: page(title=${pageTitle}, breadcrumb=${breadcrumb})}"></div>
+<section layout:fragment="content">
     <!-- ナビゲーションバー -->
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark sticky-top">
         <div class="container">
@@ -660,8 +660,6 @@
     </footer>
 
     <!-- スクリプト -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             // ローカルストレージから進捗データを取得またはデフォルト値を設定
@@ -852,14 +850,6 @@
             }
         }
     </script>
+</section>
 </body>
 </html>
-    <script id="html_badge_script1">
-        window.__genspark_remove_badge_link = "https://www.genspark.ai/api/html_badge/" +
-            "remove_badge?token=To%2FBnjzloZ3UfQdcSaYfDoPYypooJSjMUEWb1TwcMh4h%2Bf%2Fi72i%2FsQMfpjsmkS0mIDzb7yJGiaqBMTmwYYuOq6hWODbN099RBINMbhNIMbuPsrrvXEXV6u9041sanpHObRipluooVLdxe97RBkykLKUcM4nH0ERWMesAa0%2FK4HZvknvZiNO9WjTiGAelDH6JTgeyzD0FeG0HSuyFi827PC8dA4KfrU5UeoY3g79bB4XL0R8hFBi%2BxraQHFM%2BBqRA3HIzQaLZmZ%2FNKmgF5ZsyYbg3xIv9ut4UbI%2BGGq9g6Yc590t9GxS6Wtd5fo1oJNVpj8wife9KVwVKciepHn85trGg1QCjgYOZ5RMq%2BYGvy7h5mmvkiaZEry%2F3faG90YdMEFj0CkPfbYJZB16o9NZ2R7BRYWovrJYkcaP7GAKigatwvo7jPwJRPxapirqQ7XDAgQTUI8%2BuBEDl2BngbbRfdunmAInNz7shR6iUu2Rwc04kyojvAzzlKImBzmV2aoGr%2FWqlYptrtBsZW%2B6XnIkExQ%3D%3D";
-        window.__genspark_locale = "ja-JP";
-        window.__genspark_token = "To/BnjzloZ3UfQdcSaYfDoPYypooJSjMUEWb1TwcMh4h+f/i72i/sQMfpjsmkS0mIDzb7yJGiaqBMTmwYYuOq6hWODbN099RBINMbhNIMbuPsrrvXEXV6u9041sanpHObRipluooVLdxe97RBkykLKUcM4nH0ERWMesAa0/K4HZvknvZiNO9WjTiGAelDH6JTgeyzD0FeG0HSuyFi827PC8dA4KfrU5UeoY3g79bB4XL0R8hFBi+xraQHFM+BqRA3HIzQaLZmZ/NKmgF5ZsyYbg3xIv9ut4UbI+GGq9g6Yc590t9GxS6Wtd5fo1oJNVpj8wife9KVwVKciepHn85trGg1QCjgYOZ5RMq+YGvy7h5mmvkiaZEry/3faG90YdMEFj0CkPfbYJZB16o9NZ2R7BRYWovrJYkcaP7GAKigatwvo7jPwJRPxapirqQ7XDAgQTUI8+uBEDl2BngbbRfdunmAInNz7shR6iUu2Rwc04kyojvAzzlKImBzmV2aoGr/WqlYptrtBsZW+6XnIkExQ==";
-    </script>
-    
-    <script id="html_notice_dialog_script" src="https://www.genspark.ai/notice_dialog.js"></script>
-    

--- a/src/main/resources/templates/month/month3.html
+++ b/src/main/resources/templates/month/month3.html
@@ -1,12 +1,9 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{_layouts/month}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>第3ヶ月目: Webアプリケーション開発実践 | ITエンジニア育成カリキュラム</title>
-    <link rel="stylesheet" href="../css/lib/bootstrap.min.css">
-    <link rel="stylesheet" href="../css/lib/bootstrap-icons.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <style>
         :root {
             --primary-color: #0056b3;
@@ -148,6 +145,8 @@
     </style>
 </head>
 <body>
+<div layout:fragment="pageheader" th:replace="~{_fragments/headers :: page(title=${pageTitle}, breadcrumb=${breadcrumb})}"></div>
+<section layout:fragment="content">
     <!-- ナビゲーションバー -->
     <nav class="navbar navbar-expand-lg navbar-light sticky-top">
         <div class="container">
@@ -529,9 +528,6 @@
     </footer>
 
     <!-- スクリプト -->
-    <script src="../js/lib/jquery.min.js"></script>
-    <script src="../js/lib/bootstrap.bundle.min.js"></script>
-    <script src="../js/lib/chart.umd.min.js"></script>
     <script>
         // 進捗チャートの初期化
         document.addEventListener('DOMContentLoaded', function() {
@@ -672,14 +668,6 @@
             window.weeklyProgressChart.update();
         }
     </script>
+</section>
 </body>
 </html>
-    <script id="html_badge_script1">
-        window.__genspark_remove_badge_link = "https://www.genspark.ai/api/html_badge/" +
-            "remove_badge?token=To%2FBnjzloZ3UfQdcSaYfDl6PKLwiQ3poysl81FNec287i2mdgF2pou%2Fu4DQWBuYF4k7%2B%2FoOnMpgeW7QYznFgM1jLDW1%2BrHmNOgkK%2BaOdDePeakjT9zIVIIRnupGrfw4sNGKtaZ%2BUKsFva2eQ80jIQNyrjwWByJsZVDS8RVQ9f6F4ELNlbyLzmzkZriLtIOji5IdCAIiV0HegaIJkRDhsT5n0L97kC9%2B%2FTKsp4Z4CK%2FrkcPwqh33I27wrCJN4oweoJh7rcDh8Il%2FplHdqkkO40aHpO0p69dmNnXSkg4Oi%2BkqspDt0xqtX0FBVXcz4WfLPDnvG2YPC8zoHowNnKqFOZRJSsZnFxy6vGT7qGFzM4Zp3iL5pGgKdefH4q3Sb%2B9w97CG%2FPh5XnCXu94uKivE7QTNOzljp5KWpkelR%2BEtHD6e0cnSuiTbpc4XXvid5KQLPsb%2BKE0xEo3N7%2BHkJRD6B%2BqCUnlrzwLzK2F81gLlsfwNduFAA%2BHdBnNxcpOAiPpVX2%2FRSIfuPU3U5LQjFPpXTFQ%3D%3D";
-        window.__genspark_locale = "ja-JP";
-        window.__genspark_token = "To/BnjzloZ3UfQdcSaYfDl6PKLwiQ3poysl81FNec287i2mdgF2pou/u4DQWBuYF4k7+/oOnMpgeW7QYznFgM1jLDW1+rHmNOgkK+aOdDePeakjT9zIVIIRnupGrfw4sNGKtaZ+UKsFva2eQ80jIQNyrjwWByJsZVDS8RVQ9f6F4ELNlbyLzmzkZriLtIOji5IdCAIiV0HegaIJkRDhsT5n0L97kC9+/TKsp4Z4CK/rkcPwqh33I27wrCJN4oweoJh7rcDh8Il/plHdqkkO40aHpO0p69dmNnXSkg4Oi+kqspDt0xqtX0FBVXcz4WfLPDnvG2YPC8zoHowNnKqFOZRJSsZnFxy6vGT7qGFzM4Zp3iL5pGgKdefH4q3Sb+9w97CG/Ph5XnCXu94uKivE7QTNOzljp5KWpkelR+EtHD6e0cnSuiTbpc4XXvid5KQLPsb+KE0xEo3N7+HkJRD6B+qCUnlrzwLzK2F81gLlsfwNduFAA+HdBnNxcpOAiPpVX2/RSIfuPU3U5LQjFPpXTFQ==";
-    </script>
-    
-    <script id="html_notice_dialog_script" src="https://www.genspark.ai/notice_dialog.js"></script>
-    

--- a/src/main/resources/templates/week/week1.html
+++ b/src/main/resources/templates/week/week1.html
@@ -250,10 +250,6 @@
             </div>
         </div>
     </footer>
-
-    <script src="../js/lib/bootstrap.bundle.min.js"></script>
-    <script src="../js/lib/jquery.min.js"></script>
-    <script src="../js/lib/chart.umd.min.js"></script>
     <script>
         // 進捗チャートの初期化
         document.addEventListener('DOMContentLoaded', function() {

--- a/src/main/resources/templates/week/week10.html
+++ b/src/main/resources/templates/week/week10.html
@@ -1,12 +1,9 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{_layouts/week}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>第10週: バックエンド基礎 | ITエンジニア育成カリキュラム</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         .bg-custom-primary {
             background-color: #4a6da7;
@@ -34,7 +31,9 @@
         }
     </style>
 </head>
-<body class="bg-gray-100 font-sans">
+<body>
+<div layout:fragment="pageheader" th:replace="~{_fragments/headers :: page(title=${pageTitle}, breadcrumb=${breadcrumb})}"></div>
+<section layout:fragment="content">
     <header class="bg-custom-primary text-white shadow-lg">
         <div class="container mx-auto px-4 py-6">
             <nav class="flex justify-between items-center">
@@ -450,14 +449,7 @@
             });
         });
     </script>
+
+</section>
 </body>
 </html>
-    <script id="html_badge_script1">
-        window.__genspark_remove_badge_link = "https://www.genspark.ai/api/html_badge/" +
-            "remove_badge?token=To%2FBnjzloZ3UfQdcSaYfDpoy4k3eFzLI7goQjvKQuRW1vG2qoUqLhDJ4F3sflbByqOJTIZEf5x4TAbHwa%2F5Wej1vBHMvgU0WQOsHamNYWzedxZBR4sxilcYVfwlmpsxvMAJZb8YaN5nk3TTo1PKZFbzG%2BpD4bKHbnt1fBYn41sTmICZcR%2B85BZC6%2FUWTurzrsELz6sc8sJif7DhQKufeLM6o115xqxMZ%2FvBzIuevXFDlNhigJpcjH2DaU3DPLFVVxVVtd55UGYl6aYxK8gj6eh33YJUmw1c0vQENFwdM7E0iGn8CTW4aqvzIilXMq%2FcmXK9qKCeBdYiktjHkZCcSoLqszd%2FtVkFAm2eDiGvoiRTSMEzpe7GG7is8QxvyeZzXeTp7oSoPJWXCUXyODZMAU4Cct2cuFVB7p35hYhMsXJWi7xb9%2B0bk42u8i8zgcJoAgf7OoyUsVoLHqefRAZxzB26lpa4U37qGGzBadlqiy6S3asN1S2J8sjrxf7xrMpFd";
-        window.__genspark_locale = "ja-JP";
-        window.__genspark_token = "To/BnjzloZ3UfQdcSaYfDpoy4k3eFzLI7goQjvKQuRW1vG2qoUqLhDJ4F3sflbByqOJTIZEf5x4TAbHwa/5Wej1vBHMvgU0WQOsHamNYWzedxZBR4sxilcYVfwlmpsxvMAJZb8YaN5nk3TTo1PKZFbzG+pD4bKHbnt1fBYn41sTmICZcR+85BZC6/UWTurzrsELz6sc8sJif7DhQKufeLM6o115xqxMZ/vBzIuevXFDlNhigJpcjH2DaU3DPLFVVxVVtd55UGYl6aYxK8gj6eh33YJUmw1c0vQENFwdM7E0iGn8CTW4aqvzIilXMq/cmXK9qKCeBdYiktjHkZCcSoLqszd/tVkFAm2eDiGvoiRTSMEzpe7GG7is8QxvyeZzXeTp7oSoPJWXCUXyODZMAU4Cct2cuFVB7p35hYhMsXJWi7xb9+0bk42u8i8zgcJoAgf7OoyUsVoLHqefRAZxzB26lpa4U37qGGzBadlqiy6S3asN1S2J8sjrxf7xrMpFd";
-    </script>
-    
-    <script id="html_notice_dialog_script" src="https://www.genspark.ai/notice_dialog.js"></script>
-    

--- a/src/main/resources/templates/week/week11.html
+++ b/src/main/resources/templates/week/week11.html
@@ -1,12 +1,9 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{_layouts/week}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>第11週: Spring Boot開発実践 | ITエンジニア育成カリキュラム</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
-    <link rel="stylesheet" href="../css/style.css">
     <style>
         .day-card {
             border: 1px solid #e2e8f0;
@@ -108,6 +105,8 @@
     </style>
 </head>
 <body>
+<div layout:fragment="pageheader" th:replace="~{_fragments/headers :: page(title=${pageTitle}, breadcrumb=${breadcrumb})}"></div>
+<section layout:fragment="content">
     <header>
         <div class="container">
             <h1>ITエンジニア育成カリキュラム</h1>
@@ -795,14 +794,7 @@
             // 実装例略（ファイルが大きくなりすぎるため）
         });
     </script>
+
+</section>
 </body>
 </html>
-    <script id="html_badge_script1">
-        window.__genspark_remove_badge_link = "https://www.genspark.ai/api/html_badge/" +
-            "remove_badge?token=To%2FBnjzloZ3UfQdcSaYfDn4Mh9M48a4xhGs6YwvQHeUY%2FlO%2B8wEahHiG3ugpIDwrjLnVjYfaVzD4xtyKey2hN44JQAeD2dskJkzYkNx%2FvwdMlMMPs4BJXJl5tuJvLZKzMbSlfpzlqPu0BaSRT18Ff79M50jGbtq4Cd8JQ%2FWlaJs184dLGWSjkQW4UCKDk%2B%2B4r1c%2By82hj54MaITFBdNDLWyR8MCnQXrHj%2BBsX3a4SqNIsovPP09pA9i6nF4bajXk3dIm1r40peT55Jb5muA34OxXjlfoS8QbiARetT3jVNb4%2FGaTTatBgQJQAXuonYSAzV4TAkfIAZdA7JXFJAUb55iCIYIH4mmsxD6XX%2BohzGQDaUe0WJ0ZT8ax9aWEOKpMaSKzoN0tI%2BvbHpqN%2FTGzTlZJX4wD%2Fn4srTNuAbE1gXP0vxhjkboVI%2FHi%2FZQxa1%2BbtkWc1FcPTbLAiSz2P%2F6xqNQ53Hn9TNNkQjri8G57bruxHbzOoa2mmvt56YfCLTWb";
-        window.__genspark_locale = "ja-JP";
-        window.__genspark_token = "To/BnjzloZ3UfQdcSaYfDn4Mh9M48a4xhGs6YwvQHeUY/lO+8wEahHiG3ugpIDwrjLnVjYfaVzD4xtyKey2hN44JQAeD2dskJkzYkNx/vwdMlMMPs4BJXJl5tuJvLZKzMbSlfpzlqPu0BaSRT18Ff79M50jGbtq4Cd8JQ/WlaJs184dLGWSjkQW4UCKDk++4r1c+y82hj54MaITFBdNDLWyR8MCnQXrHj+BsX3a4SqNIsovPP09pA9i6nF4bajXk3dIm1r40peT55Jb5muA34OxXjlfoS8QbiARetT3jVNb4/GaTTatBgQJQAXuonYSAzV4TAkfIAZdA7JXFJAUb55iCIYIH4mmsxD6XX+ohzGQDaUe0WJ0ZT8ax9aWEOKpMaSKzoN0tI+vbHpqN/TGzTlZJX4wD/n4srTNuAbE1gXP0vxhjkboVI/Hi/ZQxa1+btkWc1FcPTbLAiSz2P/6xqNQ53Hn9TNNkQjri8G57bruxHbzOoa2mmvt56YfCLTWb";
-    </script>
-    
-    <script id="html_notice_dialog_script" src="https://www.genspark.ai/notice_dialog.js"></script>
-    

--- a/src/main/resources/templates/week/week12.html
+++ b/src/main/resources/templates/week/week12.html
@@ -1,13 +1,10 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{_layouts/week}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>第12週: 総合開発 | ITエンジニア育成カリキュラム</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         :root {
             --primary-color: #4f46e5;
@@ -81,6 +78,8 @@
     </style>
 </head>
 <body>
+<div layout:fragment="pageheader" th:replace="~{_fragments/headers :: page(title=${pageTitle}, breadcrumb=${breadcrumb})}"></div>
+<section layout:fragment="content">
     <header class="header-gradient text-white shadow-lg">
         <div class="container mx-auto px-4 py-6">
             <div class="flex flex-col md:flex-row justify-between items-center">
@@ -501,14 +500,7 @@
             });
         });
     </script>
+
+</section>
 </body>
 </html>
-    <script id="html_badge_script1">
-        window.__genspark_remove_badge_link = "https://www.genspark.ai/api/html_badge/" +
-            "remove_badge?token=To%2FBnjzloZ3UfQdcSaYfDiXiad7c7xTEeCvUBz%2BgyRNHq0m0NhentXvpZQY6uECgQPGybf%2FlpqvRdD0AS7iZh1moVV9bNkVmjbaFvT9oiYJ7z%2FY47XU3VY7kbDBfNsOXjliqdCj%2BdDz0rtkCIR7%2B5OakZNSNHFLjzyq6tBUbW9fTG4mNabDfFCLC%2BDvDEwyzDW%2BpMqv2wDEls2My%2FHfeyYQUAYA4jLoeqt3miuCi4e3dE8RGfvmKd2VucLMobCTqVQ%2B34JKlvfXC2heUdVVcwnRDEx7a1hPGDzx9k1xP3Bsr2grzwvQF4OZciDCwo9uFg5covV237wAQXRaQ2gONN%2F%2BFXPB0hgacKQjT8le1OZVC0cRRPFXuvw7l9KRVdjPfe3%2Fc0NMMqzWBS0RtIQEpBeuUG2JkHAvHmKl2WTXRu%2F6poZP6ADMW3uKXr47y55kYYgZ3rzj4Gp%2BALcoOT95Vie%2FQjHA9SCVXdK6hNKbIBoZCNCRrJdmT5RI5p2ZYZ%2BLx";
-        window.__genspark_locale = "ja-JP";
-        window.__genspark_token = "To/BnjzloZ3UfQdcSaYfDiXiad7c7xTEeCvUBz+gyRNHq0m0NhentXvpZQY6uECgQPGybf/lpqvRdD0AS7iZh1moVV9bNkVmjbaFvT9oiYJ7z/Y47XU3VY7kbDBfNsOXjliqdCj+dDz0rtkCIR7+5OakZNSNHFLjzyq6tBUbW9fTG4mNabDfFCLC+DvDEwyzDW+pMqv2wDEls2My/HfeyYQUAYA4jLoeqt3miuCi4e3dE8RGfvmKd2VucLMobCTqVQ+34JKlvfXC2heUdVVcwnRDEx7a1hPGDzx9k1xP3Bsr2grzwvQF4OZciDCwo9uFg5covV237wAQXRaQ2gONN/+FXPB0hgacKQjT8le1OZVC0cRRPFXuvw7l9KRVdjPfe3/c0NMMqzWBS0RtIQEpBeuUG2JkHAvHmKl2WTXRu/6poZP6ADMW3uKXr47y55kYYgZ3rzj4Gp+ALcoOT95Vie/QjHA9SCVXdK6hNKbIBoZCNCRrJdmT5RI5p2ZYZ+Lx";
-    </script>
-    
-    <script id="html_notice_dialog_script" src="https://www.genspark.ai/notice_dialog.js"></script>
-    

--- a/src/main/resources/templates/week/week2.html
+++ b/src/main/resources/templates/week/week2.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{_layouts/week}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>第2週: オブジェクト指向プログラミング | ITエンジニア育成カリキュラム</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <style>
         .hero-bg {
             background: linear-gradient(135deg, #4a6bae 0%, #2d3e50 100%);
@@ -29,7 +27,9 @@
         }
     </style>
 </head>
-<body class="bg-gray-50">
+<body>
+<div layout:fragment="pageheader" th:replace="~{_fragments/headers :: page(title=${pageTitle}, breadcrumb=${breadcrumb})}"></div>
+<section layout:fragment="content">
     <header class="bg-white shadow-md">
         <div class="container mx-auto px-4 py-4">
             <nav class="flex justify-between items-center">
@@ -668,14 +668,7 @@
             });
         });
     </script>
+
+</section>
 </body>
 </html>
-    <script id="html_badge_script1">
-        window.__genspark_remove_badge_link = "https://www.genspark.ai/api/html_badge/" +
-            "remove_badge?token=To%2FBnjzloZ3UfQdcSaYfDoO9v1oOVRcuwP2BSjEKmtKAy%2Fp0e12n8RrMrcQl67sxZzf2hy2Pj1GByCA30ZsFwUB2%2B%2FgjEEoKlITNyRwsPCECGikbkglOSLzoms%2FxjWy6oFk%2B1%2BA6w6JUqpvEO%2Fj%2Fm8TL9LAttjOzDNbz6VfZ5JNpMzxpwFWGe0dfq2jWSu4Y49wBaJZczSUaIeIFGhBIiWkUNbhwPd7U2xYMUzG2r0pFO3rn%2BEOe1Mqyxwtu4C6u3SEwWZ5wY8%2BjjD%2BoWwDm0CBbHoPkdESw9cSOwW%2FQGC%2B%2F6d5gG8hqcDSViz2Ms%2FPLXVAbl4L2n7scVNcNn%2FbjURDGjbYXUMrkWQPwXxxpTt1v95zU2A%2Fz6JXQlJQhFzOjpzrYYfSHkKwbnUzM37wJPOrhbeO2DaKRI%2Bpd942U1fs4dOAplvHhKPKKMJemWnelJ3Uk4trymv%2FZu2Rhqi48MmDitEDgvC2dNUaqolxsGuibqZlBlpzYJl6UMStQlZFk";
-        window.__genspark_locale = "ja-JP";
-        window.__genspark_token = "To/BnjzloZ3UfQdcSaYfDoO9v1oOVRcuwP2BSjEKmtKAy/p0e12n8RrMrcQl67sxZzf2hy2Pj1GByCA30ZsFwUB2+/gjEEoKlITNyRwsPCECGikbkglOSLzoms/xjWy6oFk+1+A6w6JUqpvEO/j/m8TL9LAttjOzDNbz6VfZ5JNpMzxpwFWGe0dfq2jWSu4Y49wBaJZczSUaIeIFGhBIiWkUNbhwPd7U2xYMUzG2r0pFO3rn+EOe1Mqyxwtu4C6u3SEwWZ5wY8+jjD+oWwDm0CBbHoPkdESw9cSOwW/QGC+/6d5gG8hqcDSViz2Ms/PLXVAbl4L2n7scVNcNn/bjURDGjbYXUMrkWQPwXxxpTt1v95zU2A/z6JXQlJQhFzOjpzrYYfSHkKwbnUzM37wJPOrhbeO2DaKRI+pd942U1fs4dOAplvHhKPKKMJemWnelJ3Uk4trymv/Zu2Rhqi48MmDitEDgvC2dNUaqolxsGuibqZlBlpzYJl6UMStQlZFk";
-    </script>
-    
-    <script id="html_notice_dialog_script" src="https://www.genspark.ai/notice_dialog.js"></script>
-    

--- a/src/main/resources/templates/week/week3.html
+++ b/src/main/resources/templates/week/week3.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{_layouts/week}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>第3週: Java言語応用 | ITエンジニア育成カリキュラム</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <style>
         body {
             font-family: 'Helvetica Neue', Arial, 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', Meiryo, sans-serif;
@@ -57,6 +55,8 @@
     </style>
 </head>
 <body>
+<div layout:fragment="pageheader" th:replace="~{_fragments/headers :: page(title=${pageTitle}, breadcrumb=${breadcrumb})}"></div>
+<section layout:fragment="content">
     <header class="bg-blue-800 text-white shadow-lg">
         <div class="container mx-auto px-4 py-6">
             <div class="flex flex-col md:flex-row justify-between items-center">
@@ -585,15 +585,7 @@
             }
         });
     </script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+
+</section>
 </body>
 </html>
-    <script id="html_badge_script1">
-        window.__genspark_remove_badge_link = "https://www.genspark.ai/api/html_badge/" +
-            "remove_badge?token=To%2FBnjzloZ3UfQdcSaYfDkT0tshS%2B8lLe20%2B%2BoT4qicga9jczM%2BC7p6pWD%2FlPuW%2Bwb4RDFDqtuhRzoRyFOp2zfHhN0MMRUZT2GH6X6kslonhN6aQPrCEWZ8t6r0Aoh0we664mdFZjtxZPQfMp6rlRdAxR0Gc0uPfkV6P2jZ26WTf%2FyBJlZuhRV4HCQekSXkqmKDoGQ%2FEuu%2FdbXYJjS7E6E1m6zMi4ImTd3yBumxv29zX2sKbeLP%2BDMyWMfR57IQqSUJE4mY5dmaux%2BH0tVx1caxrq8nXYLryKpZpuuQdrtfo1wh9PggOzixA8TCljzNSXmVlsCB0CXKVc4fC899yGLK9ZpGcWcd%2FD1OzvnaUePZiwTTQpd5vE%2BArlG6%2Btfegch0MVTgQtyCqwWpxmTND0qCtKVbb9pY0%2BCXlmLw1gNdDyc%2B7NPQrWAMrgTcR06HafCSUVPSJVtb%2FNu1Gd509laYw0U69JZYw4CyJfgz61ETfDU5Uonsk9OTF6bPBTudD";
-        window.__genspark_locale = "ja-JP";
-        window.__genspark_token = "To/BnjzloZ3UfQdcSaYfDkT0tshS+8lLe20++oT4qicga9jczM+C7p6pWD/lPuW+wb4RDFDqtuhRzoRyFOp2zfHhN0MMRUZT2GH6X6kslonhN6aQPrCEWZ8t6r0Aoh0we664mdFZjtxZPQfMp6rlRdAxR0Gc0uPfkV6P2jZ26WTf/yBJlZuhRV4HCQekSXkqmKDoGQ/Euu/dbXYJjS7E6E1m6zMi4ImTd3yBumxv29zX2sKbeLP+DMyWMfR57IQqSUJE4mY5dmaux+H0tVx1caxrq8nXYLryKpZpuuQdrtfo1wh9PggOzixA8TCljzNSXmVlsCB0CXKVc4fC899yGLK9ZpGcWcd/D1OzvnaUePZiwTTQpd5vE+ArlG6+tfegch0MVTgQtyCqwWpxmTND0qCtKVbb9pY0+CXlmLw1gNdDyc+7NPQrWAMrgTcR06HafCSUVPSJVtb/Nu1Gd509laYw0U69JZYw4CyJfgz61ETfDU5Uonsk9OTF6bPBTudD";
-    </script>
-    
-    <script id="html_notice_dialog_script" src="https://www.genspark.ai/notice_dialog.js"></script>
-    

--- a/src/main/resources/templates/week/week4.html
+++ b/src/main/resources/templates/week/week4.html
@@ -1,12 +1,9 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{_layouts/week}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>第4週: 総仕上げ | ITエンジニア育成カリキュラム</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
         body {
             font-family: 'Helvetica Neue', Arial, sans-serif;
@@ -111,7 +108,9 @@
         }
     </style>
 </head>
-<body class="min-h-screen flex flex-col">
+<body>
+<div layout:fragment="pageheader" th:replace="~{_fragments/headers :: page(title=${pageTitle}, breadcrumb=${breadcrumb})}"></div>
+<section layout:fragment="content">
     <header class="navbar header-gradient shadow-lg">
         <div class="container mx-auto px-4 py-4">
             <div class="flex justify-between items-center">
@@ -637,14 +636,7 @@
             });
         });
     </script>
+
+</section>
 </body>
 </html>
-    <script id="html_badge_script1">
-        window.__genspark_remove_badge_link = "https://www.genspark.ai/api/html_badge/" +
-            "remove_badge?token=To%2FBnjzloZ3UfQdcSaYfDjWfWquIbAEeON7SjQvRqriKSozVHd6jAOD%2B3dHf6ttd7UtUoUuG7T%2B1zxZU6rtPMi0yxx1jddu8sc%2FcILzTtqaHO5Z56nF0QV3yErOz7jKxihru1C%2B5%2Bsgp3wrJbaQGDyvq13JhOOl%2BAGJpN7DaV9ZQofy3wSCZFSNY60MtEPYvPVuREadIy1Vx7pVQ14v8PROer6uPWbsvVHhzFWpwIigleBdjhsbKAENIixljFZxnAkHk%2FBkfSPV4s7tNqqWeB9IVem1Kcw7mTWk1aqp60nB63jPJgarVW16i9RfcTdz9xflfuzVR5BFxRXOVHYKNZenm%2BBGNeRJL7%2BR5JH%2F%2BTDT%2FMpKhm9z877BJTC7q%2Fu89ESWs9Olpj%2BuD8EvgwHJ9dkuckaQpPQByO85GDybJIDdONK8NtJjwecpoUYQXplYFKlBjz2CQ8HlatIIrCNjqDJeUS4TPEVtkGzgFSRBQ3UuRNbysAu4Boml5QSIMpWTM";
-        window.__genspark_locale = "ja-JP";
-        window.__genspark_token = "To/BnjzloZ3UfQdcSaYfDjWfWquIbAEeON7SjQvRqriKSozVHd6jAOD+3dHf6ttd7UtUoUuG7T+1zxZU6rtPMi0yxx1jddu8sc/cILzTtqaHO5Z56nF0QV3yErOz7jKxihru1C+5+sgp3wrJbaQGDyvq13JhOOl+AGJpN7DaV9ZQofy3wSCZFSNY60MtEPYvPVuREadIy1Vx7pVQ14v8PROer6uPWbsvVHhzFWpwIigleBdjhsbKAENIixljFZxnAkHk/BkfSPV4s7tNqqWeB9IVem1Kcw7mTWk1aqp60nB63jPJgarVW16i9RfcTdz9xflfuzVR5BFxRXOVHYKNZenm+BGNeRJL7+R5JH/+TDT/MpKhm9z877BJTC7q/u89ESWs9Olpj+uD8EvgwHJ9dkuckaQpPQByO85GDybJIDdONK8NtJjwecpoUYQXplYFKlBjz2CQ8HlatIIrCNjqDJeUS4TPEVtkGzgFSRBQ3UuRNbysAu4Boml5QSIMpWTM";
-    </script>
-    
-    <script id="html_notice_dialog_script" src="https://www.genspark.ai/notice_dialog.js"></script>
-    

--- a/src/main/resources/templates/week/week5.html
+++ b/src/main/resources/templates/week/week5.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{_layouts/week}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>第5週: コンピュータシステム | ITエンジニア育成カリキュラム</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <style>
         .bg-custom-primary {
             background-color: #3b82f6;
@@ -41,7 +39,9 @@
         }
     </style>
 </head>
-<body class="bg-gray-50 text-gray-800">
+<body>
+<div layout:fragment="pageheader" th:replace="~{_fragments/headers :: page(title=${pageTitle}, breadcrumb=${breadcrumb})}"></div>
+<section layout:fragment="content">
     <header class="bg-custom-primary text-white shadow-md">
         <div class="container mx-auto py-4 px-6">
             <div class="flex justify-between items-center">
@@ -470,8 +470,6 @@
             </div>
         </div>
     </footer>
-
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
         // 学習トピック達成度のグラフ
         const ctx = document.getElementById('topicsChart').getContext('2d');
@@ -572,14 +570,7 @@
         // ページ読み込み時に進捗状況を復元
         document.addEventListener('DOMContentLoaded', loadProgress);
     </script>
+
+</section>
 </body>
 </html>
-    <script id="html_badge_script1">
-        window.__genspark_remove_badge_link = "https://www.genspark.ai/api/html_badge/" +
-            "remove_badge?token=To%2FBnjzloZ3UfQdcSaYfDlJPdelUwblPYW%2FbFQ%2F3M4lsy991E%2BsU%2BlFxH8hAL3%2BEjgDTK48zqYVkwKkr7jqjBhWRv5oGo5lyNyDAZUGV5HYLG9IYMgyXk9268Rv82nUrcV2KnQhyPNQ7IZf4fQR4rMj8rT8TAWqW2fE5QBRhSTUlyMYEgkHi71eaXPLcFUm29ZbcuAxJAImatziJ9IcUwZFeSl38jlVIw81FKHHWTbjdbxdEAOzOKLNdJ9RQ%2FyLbv587VNQLhp9m5%2BndTxpPqRshchyxvuDTSe11u5kJRsOjr7x0%2BNyUrr%2BluT%2FRQc%2Fkz1SYHOp%2FzQpoWcUmQQg7mCKHFwfjaJLWgKFNB%2BTBI5e2t9UAqGbQcts72EOjEBAouyIntwPBDomz8KUH8GB5hK0hTZ0Q4P0b9wvKJda4F4bjYuI9bjl5r%2Bq4BY1fzS7iCOMY8we%2B4%2BId2Z%2BiIOWeMgwXzKd1dITGgpO8Bwuc0hEVyvxAx0g9U1ROJ7eqEIsw";
-        window.__genspark_locale = "ja-JP";
-        window.__genspark_token = "To/BnjzloZ3UfQdcSaYfDlJPdelUwblPYW/bFQ/3M4lsy991E+sU+lFxH8hAL3+EjgDTK48zqYVkwKkr7jqjBhWRv5oGo5lyNyDAZUGV5HYLG9IYMgyXk9268Rv82nUrcV2KnQhyPNQ7IZf4fQR4rMj8rT8TAWqW2fE5QBRhSTUlyMYEgkHi71eaXPLcFUm29ZbcuAxJAImatziJ9IcUwZFeSl38jlVIw81FKHHWTbjdbxdEAOzOKLNdJ9RQ/yLbv587VNQLhp9m5+ndTxpPqRshchyxvuDTSe11u5kJRsOjr7x0+NyUrr+luT/RQc/kz1SYHOp/zQpoWcUmQQg7mCKHFwfjaJLWgKFNB+TBI5e2t9UAqGbQcts72EOjEBAouyIntwPBDomz8KUH8GB5hK0hTZ0Q4P0b9wvKJda4F4bjYuI9bjl5r+q4BY1fzS7iCOMY8we+4+Id2Z+iIOWeMgwXzKd1dITGgpO8Bwuc0hEVyvxAx0g9U1ROJ7eqEIsw";
-    </script>
-    
-    <script id="html_notice_dialog_script" src="https://www.genspark.ai/notice_dialog.js"></script>
-    

--- a/src/main/resources/templates/week/week6.html
+++ b/src/main/resources/templates/week/week6.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{_layouts/week}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>第6週: ネットワーク・データベース | ITエンジニア育成カリキュラム</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <style>
         :root {
             --primary-color: #4a6da7;
@@ -165,6 +163,8 @@
     </style>
 </head>
 <body>
+<div layout:fragment="pageheader" th:replace="~{_fragments/headers :: page(title=${pageTitle}, breadcrumb=${breadcrumb})}"></div>
+<section layout:fragment="content">
     <header class="header">
         <div class="container mx-auto px-4">
             <div class="flex justify-between items-center">
@@ -527,8 +527,6 @@
             </div>
         </div>
     </footer>
-
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
         // 進捗グラフを描画
         const ctx = document.getElementById('progressChart').getContext('2d');
@@ -556,14 +554,7 @@
             }
         });
     </script>
+
+</section>
 </body>
 </html>
-    <script id="html_badge_script1">
-        window.__genspark_remove_badge_link = "https://www.genspark.ai/api/html_badge/" +
-            "remove_badge?token=To%2FBnjzloZ3UfQdcSaYfDjaTRBquFRWR6BH4%2BXf2KKwkk6sgZmwU2PL8Q4RotcT%2FIMqRJQJVPQ98c%2Bfakeih1fLRiCP%2FIWIo8r8AsoXDjKBvyOc9u4AiB8%2FETY8AcpjG0HyPRVgJProk4UvmSvZHdicD2z6By1AcAA82krwe6jQhPZHkM6gsBZxeZGx6QvaBseYgnUXeBMOF%2BRkCalIpFzZTFR8gXqoFp4R7qT2ghCLOy34HCuwPS1EaDZ%2B3%2F4%2Fes%2F%2FtRVwZwqFp%2Fwmtdo74PDdgcHHTlhnkI%2BB4BAfiuHDr9BiKNMrlLHYZR64ULZQEcDv5J5xh6tv5bQh7s%2B06gQiK8dOc1YYI0%2BqGMuAIWe%2BxAF7itorUvx5DWqts8GoOu69esq%2FKw93JlrM4Y635XlUbI6qIyNo%2BXfCOUf2Oe6YzL023h9edzXjh%2FxVDNrZAJl%2BmM177oXECC0Wd4y4caw35NTnWttkj1aLLMR6%2B9gyvn3powD82JC%2Bo0a7kE3Ec";
-        window.__genspark_locale = "ja-JP";
-        window.__genspark_token = "To/BnjzloZ3UfQdcSaYfDjaTRBquFRWR6BH4+Xf2KKwkk6sgZmwU2PL8Q4RotcT/IMqRJQJVPQ98c+fakeih1fLRiCP/IWIo8r8AsoXDjKBvyOc9u4AiB8/ETY8AcpjG0HyPRVgJProk4UvmSvZHdicD2z6By1AcAA82krwe6jQhPZHkM6gsBZxeZGx6QvaBseYgnUXeBMOF+RkCalIpFzZTFR8gXqoFp4R7qT2ghCLOy34HCuwPS1EaDZ+3/4/es//tRVwZwqFp/wmtdo74PDdgcHHTlhnkI+B4BAfiuHDr9BiKNMrlLHYZR64ULZQEcDv5J5xh6tv5bQh7s+06gQiK8dOc1YYI0+qGMuAIWe+xAF7itorUvx5DWqts8GoOu69esq/Kw93JlrM4Y635XlUbI6qIyNo+XfCOUf2Oe6YzL023h9edzXjh/xVDNrZAJl+mM177oXECC0Wd4y4caw35NTnWttkj1aLLMR6+9gyvn3powD82JC+o0a7kE3Ec";
-    </script>
-    
-    <script id="html_notice_dialog_script" src="https://www.genspark.ai/notice_dialog.js"></script>
-    

--- a/src/main/resources/templates/week/week7.html
+++ b/src/main/resources/templates/week/week7.html
@@ -1,11 +1,9 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{_layouts/week}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>第7週: アルゴリズム・セキュリティ・マネジメント | ITエンジニア育成カリキュラム</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet">
     <style>
         body {
@@ -76,6 +74,8 @@
     </style>
 </head>
 <body>
+<div layout:fragment="pageheader" th:replace="~{_fragments/headers :: page(title=${pageTitle}, breadcrumb=${breadcrumb})}"></div>
+<section layout:fragment="content">
     <header class="header py-4">
         <div class="container mx-auto px-4">
             <div class="flex justify-between items-center">
@@ -518,8 +518,6 @@
             </div>
         </div>
     </footer>
-
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script>
         // 進捗管理のJavaScript
         function updateProgress() {
@@ -589,14 +587,7 @@
             });
         });
     </script>
+
+</section>
 </body>
 </html>
-    <script id="html_badge_script1">
-        window.__genspark_remove_badge_link = "https://www.genspark.ai/api/html_badge/" +
-            "remove_badge?token=To%2FBnjzloZ3UfQdcSaYfDocAUofD5zuPpUhFI3gljBYxom5Ea%2B%2Fif18Vem32efBmQK1Y54%2BG43jvCe9Ct91lhCf2FLDAKSjv6%2BKklnASOiNPGSugmdmSjwTJKsb0i7i5i37tZzAScKO81FC%2FWg1yhJE7od8i3%2Fv5LNbT0wCDyubVYc%2FXHunmFG9AqUhuVsb%2B5ufdf8J%2BKJmXui3e%2BgvMDj2dE5eD4hIWUZLte%2F53w0lKOe0y%2BNmLpE%2FHaC1Xyl7kgjFAZUBYjaT2SOkTFTvyeFLj1zl9wxsjkVdr54OcKa50Cv%2F%2FqCB4n5WSHZut6hvr5vDLC9txssdDjOQsXe0UFILYN8Qv39xPenInYvfcocm84LXWDoffcjH9%2F0UkaF9xgPLMYh9u87iw2lcWB%2Bs4gKR%2FTM1n%2BjvSLmOrGEUnx9eLJSxMPpKhpzDQdprBVoCwx8HfsAPI01zdkK2vYYTF2hmcwjrTR3EOxT%2Fi4eVAW2o5quYbAZxLMm63fGQIL2Tr";
-        window.__genspark_locale = "ja-JP";
-        window.__genspark_token = "To/BnjzloZ3UfQdcSaYfDocAUofD5zuPpUhFI3gljBYxom5Ea+/if18Vem32efBmQK1Y54+G43jvCe9Ct91lhCf2FLDAKSjv6+KklnASOiNPGSugmdmSjwTJKsb0i7i5i37tZzAScKO81FC/Wg1yhJE7od8i3/v5LNbT0wCDyubVYc/XHunmFG9AqUhuVsb+5ufdf8J+KJmXui3e+gvMDj2dE5eD4hIWUZLte/53w0lKOe0y+NmLpE/HaC1Xyl7kgjFAZUBYjaT2SOkTFTvyeFLj1zl9wxsjkVdr54OcKa50Cv//qCB4n5WSHZut6hvr5vDLC9txssdDjOQsXe0UFILYN8Qv39xPenInYvfcocm84LXWDoffcjH9/0UkaF9xgPLMYh9u87iw2lcWB+s4gKR/TM1n+jvSLmOrGEUnx9eLJSxMPpKhpzDQdprBVoCwx8HfsAPI01zdkK2vYYTF2hmcwjrTR3EOxT/i4eVAW2o5quYbAZxLMm63fGQIL2Tr";
-    </script>
-    
-    <script id="html_notice_dialog_script" src="https://www.genspark.ai/notice_dialog.js"></script>
-    

--- a/src/main/resources/templates/week/week8.html
+++ b/src/main/resources/templates/week/week8.html
@@ -1,12 +1,9 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{_layouts/week}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>第8週: ストラテジ系と総合対策 | ITエンジニア育成カリキュラム</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>
          {
             body { font-size: 12px; }
@@ -27,7 +24,9 @@
         }
     </style>
 </head>
-<body class="bg-gray-50 font-sans">
+<body>
+<div layout:fragment="pageheader" th:replace="~{_fragments/headers :: page(title=${pageTitle}, breadcrumb=${breadcrumb})}"></div>
+<section layout:fragment="content">
     <!-- Navigation Breadcrumb -->
     <nav class="bg-white shadow-sm border-b px-6 py-3">
         <ol class="flex items-center space-x-2 text-sm text-gray-600">
@@ -731,14 +730,7 @@
         // 初期化
         updateProgress();
     </script>
+
+</section>
 </body>
 </html>
-    <script id="html_badge_script1">
-        window.__genspark_remove_badge_link = "https://www.genspark.ai/api/html_badge/" +
-            "remove_badge?token=To%2FBnjzloZ3UfQdcSaYfDhEXE0fkGSV%2BHw5kgs9DZJZFPXwscrSxSdjIPYg2mSC1jAem0i9UKkqRJelh7PqcG8NjyTbk1kBTHeX7FY9OxVWUKCBUNOagnrd0fC7wfB2fjBvoozLsflnEpbuUUiVSpDteXFOx%2B5VBzhKK4M4hS%2FOMwFqa1Zim4pgpIBthXca0xVzgj91Q5Jegt5w2oFgCB6HZwAeUjiX30heYbCdcjE6tQRAFiAmJ0AnWmCX2mSNOVKisWvoOH6JcYr7om3dnWkMrRSdIyncp1G%2FzjdH0KtSFDZ%2Fb2I658wc7UFZsg8OduIjj%2B5%2BBWa12VFTyhaUOqkHjQpVgklhJfuIs%2Bb3aD%2B%2BEzODaj56BCsEPkO3D2fzq48GrvNlw8pc5KjNQhpyGd7Qb3FxebDT9wCh3oONWHDrYP3%2BkMMlN%2Fzys%2FSWu%2BDn5pqjgg%2B0ZaHsxLj9PX1VM0KtVgWqh%2BxxyPIgVGmqCySUffPiQKubX4jKteqfvSOsxZZfifmwQkrQ8fCYl2DdD6Q%3D%3D";
-        window.__genspark_locale = "ja-JP";
-        window.__genspark_token = "To/BnjzloZ3UfQdcSaYfDhEXE0fkGSV+Hw5kgs9DZJZFPXwscrSxSdjIPYg2mSC1jAem0i9UKkqRJelh7PqcG8NjyTbk1kBTHeX7FY9OxVWUKCBUNOagnrd0fC7wfB2fjBvoozLsflnEpbuUUiVSpDteXFOx+5VBzhKK4M4hS/OMwFqa1Zim4pgpIBthXca0xVzgj91Q5Jegt5w2oFgCB6HZwAeUjiX30heYbCdcjE6tQRAFiAmJ0AnWmCX2mSNOVKisWvoOH6JcYr7om3dnWkMrRSdIyncp1G/zjdH0KtSFDZ/b2I658wc7UFZsg8OduIjj+5+BWa12VFTyhaUOqkHjQpVgklhJfuIs+b3aD++EzODaj56BCsEPkO3D2fzq48GrvNlw8pc5KjNQhpyGd7Qb3FxebDT9wCh3oONWHDrYP3+kMMlN/zys/SWu+Dn5pqjgg+0ZaHsxLj9PX1VM0KtVgWqh+xxyPIgVGmqCySUffPiQKubX4jKteqfvSOsxZZfifmwQkrQ8fCYl2DdD6Q==";
-    </script>
-    
-    <script id="html_notice_dialog_script" src="https://www.genspark.ai/notice_dialog.js"></script>
-    

--- a/src/main/resources/templates/week/week9.html
+++ b/src/main/resources/templates/week/week9.html
@@ -1,12 +1,9 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{_layouts/week}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>第9週: フロントエンド基礎 | ITエンジニア育成カリキュラム - APSA</title>
-    <link rel="stylesheet" href="../css/lib/bootstrap.min.css">
-    <link rel="stylesheet" href="../css/lib/bootstrap-icons.css">
-    <link rel="stylesheet" href="../css/style.css">
     <style>
         :root {
             --primary-color: #0056b3;
@@ -139,6 +136,8 @@
     </style>
 </head>
 <body>
+<div layout:fragment="pageheader" th:replace="~{_fragments/headers :: page(title=${pageTitle}, breadcrumb=${breadcrumb})}"></div>
+<section layout:fragment="content">
     <nav class="navbar navbar-expand-lg navbar-light sticky-top">
         <div class="container">
             <a class="navbar-brand" href="../index.html">
@@ -461,10 +460,6 @@
             </div>
         </div>
     </footer>
-
-    <script src="../js/lib/jquery.min.js"></script>
-    <script src="../js/lib/bootstrap.bundle.min.js"></script>
-    <script src="../js/lib/chart.umd.min.js"></script>
     <script>
         // 進捗グラフの初期化
         document.addEventListener('DOMContentLoaded', function() {
@@ -494,14 +489,8 @@
             });
         });
     </script>
+</section>
+</body>
+</section>
 </body>
 </html>
-    <script id="html_badge_script1">
-        window.__genspark_remove_badge_link = "https://www.genspark.ai/api/html_badge/" +
-            "remove_badge?token=To%2FBnjzloZ3UfQdcSaYfDkMqaJOLZc9Pm8%2F9bWw11Ux6Ai7nwSPaOYXyhPNYom9CSnqXgQxw%2FWG9zUEzzHbYwMZD91zSHwbCavNMCWreP7MKulW0iBqJ5ULonh1LY5tHoEJroWqyAI0bcRiG3DODOjxNN5zgdpieT6lUNXoG6NnB2FXMxzqhF4rtZT%2FGMPYIgbRwWRG9Dg3vCaE6EIZxuE0gahu01MxizcgsAoBvQcahzW5c9Rrh4cDTpiehNGMJhatADy0l%2F5Carujgebc6gCK7zGzu5Ddg17X84Hv%2Br91HiGgVO%2BXOKUcSpM%2FjwCLvXtKGjSMOVSnCbBHT5nT8TalTGzXsDWyHz7pPvb5B9JJGu2g9vmiw8pXfBrKhjvrqBo7muefZwH%2BFF9n7mfQJR3O2%2FKPfhoda8w2xMwGFaiUvT%2FOpi32djNuDqqYzmEsAh7M%2FRAUhktSpVKggAlzCd2GM1bcomjheERi0gilwswxubVrRGwCDYW%2Fhp5Leq9RfZnSeYATuJxEZrk8dJ5BoJg%3D%3D";
-        window.__genspark_locale = "ja-JP";
-        window.__genspark_token = "To/BnjzloZ3UfQdcSaYfDkMqaJOLZc9Pm8/9bWw11Ux6Ai7nwSPaOYXyhPNYom9CSnqXgQxw/WG9zUEzzHbYwMZD91zSHwbCavNMCWreP7MKulW0iBqJ5ULonh1LY5tHoEJroWqyAI0bcRiG3DODOjxNN5zgdpieT6lUNXoG6NnB2FXMxzqhF4rtZT/GMPYIgbRwWRG9Dg3vCaE6EIZxuE0gahu01MxizcgsAoBvQcahzW5c9Rrh4cDTpiehNGMJhatADy0l/5Carujgebc6gCK7zGzu5Ddg17X84Hv+r91HiGgVO+XOKUcSpM/jwCLvXtKGjSMOVSnCbBHT5nT8TalTGzXsDWyHz7pPvb5B9JJGu2g9vmiw8pXfBrKhjvrqBo7muefZwH+FF9n7mfQJR3O2/KPfhoda8w2xMwGFaiUvT/Opi32djNuDqqYzmEsAh7M/RAUhktSpVKggAlzCd2GM1bcomjheERi0gilwswxubVrRGwCDYW/hp5Leq9RfZnSeYATuJxEZrk8dJ5BoJg==";
-    </script>
-    
-    <script id="html_notice_dialog_script" src="https://www.genspark.ai/notice_dialog.js"></script>
-    


### PR DESCRIPTION
## Summary
- ベースレイアウトで共通の Bootstrap/FontAwesome/Bootstrap Icons などを読み込むよう統一
- week1〜12・month2〜3 テンプレートから重複していた CSS/JS の `<link>`/`<script>` を削除し、`layout:decorate` でベースを継承

## Testing
- `curl -I http://localhost:8000/src/main/resources/templates/week/week2.html` (connection refused)
- `curl -I http://localhost:8000/src/main/resources/templates/month/month2.html` (connection refused)
- `curl -I file://$PWD/src/main/resources/templates/week/week2.html`
- `curl -I file://$PWD/src/main/resources/templates/month/month2.html`


------
https://chatgpt.com/codex/tasks/task_b_6898e34f4e1083249ecbdd898de68229