### PR TITLE
refactor: Spring Security設定の非推奨APIを更新

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/jp/co/apsa/giiku/infrastructure/security/SecurityConfig.java
@@ -4,10 +4,15 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
  * セキュリティ設定クラス
+ * 
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 @Configuration
 @EnableWebSecurity
@@ -19,7 +24,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(authz -> authz
                 .anyRequest().permitAll()
             )
-            .csrf().disable();
+            .csrf(AbstractHttpConfigurer::disable);
 
         return http.build();
     }


### PR DESCRIPTION
## Summary
- Spring Securityの設定で`csrf().disable()`を`csrf(AbstractHttpConfigurer::disable)`に置き換え
- JavaDocに規定のタグを追加

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_b_68a1a4a6d8808324b3411a204d61775b