### PR TITLE
docs: add missing Javadoc tags to student DTOs and entities

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/domain/entity/BaseEntity.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/entity/BaseEntity.java
@@ -9,10 +9,10 @@ import java.time.LocalDateTime;
 /**
  * 全エンティティの基底クラス
  * 共通的な属性とメタデータを提供する
- * 
- * @author Giiku LMS Team
+ *
+ * @author 株式会社アプサ
  * @version 1.0
- * @since 2024-01
+ * @since 2025
  */
 @MappedSuperclass
 @Data

--- a/src/main/java/jp/co/apsa/giiku/domain/entity/MockTestResult.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/entity/MockTestResult.java
@@ -9,6 +9,10 @@ import java.time.Duration;
 /**
  * モックテスト結果を管理するエンティティクラス
  * 学生のテスト受験結果、スコア、時間などの詳細情報を保持します
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 @Entity
 @Table(name = "mock_test_results", indexes = {

--- a/src/main/java/jp/co/apsa/giiku/domain/entity/QuestionBank.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/entity/QuestionBank.java
@@ -7,6 +7,10 @@ import java.util.List;
 /**
  * 問題バンクエンティティ
  * LMS機能における問題管理を行う
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 @Entity
 @Table(name = "question_bank")

--- a/src/main/java/jp/co/apsa/giiku/dto/Student.java
+++ b/src/main/java/jp/co/apsa/giiku/dto/Student.java
@@ -9,10 +9,10 @@ import java.time.LocalDate;
 /**
  * 学生DTO
  * 学生の基本情報を転送するためのデータ転送オブジェクト
- * 
- * @author Giiku System
+ *
+ * @author 株式会社アプサ
  * @version 1.0
- * @since 2025-08-16
+ * @since 2025
  */
 @Data
 @AllArgsConstructor

--- a/src/main/java/jp/co/apsa/giiku/dto/StudentRequest.java
+++ b/src/main/java/jp/co/apsa/giiku/dto/StudentRequest.java
@@ -5,6 +5,10 @@ import java.time.LocalDate;
 
 /**
  * 学生情報の作成・更新リクエスト用DTOクラス
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 public class StudentRequest {
 

--- a/src/main/java/jp/co/apsa/giiku/dto/StudentResponse.java
+++ b/src/main/java/jp/co/apsa/giiku/dto/StudentResponse.java
@@ -5,6 +5,10 @@ import java.time.LocalDateTime;
 
 /**
  * 学生情報レスポンス用DTOクラス
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
  */
 public class StudentResponse {
 

--- a/src/main/java/jp/co/apsa/giiku/dto/StudentStatistics.java
+++ b/src/main/java/jp/co/apsa/giiku/dto/StudentStatistics.java
@@ -5,9 +5,10 @@ import java.time.LocalDateTime;
 
 /**
  * 学生統計情報DTO
- * 
- * @author Generated
+ *
+ * @author 株式会社アプサ
  * @version 1.0
+ * @since 2025
  */
 public class StudentStatistics {
 


### PR DESCRIPTION
## Summary
- add author, version, and since tags to Student DTOs
- standardize Javadoc tags in StudentStatistics, Student, and BaseEntity
- include required tags for QuestionBank and MockTestResult entities

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_b_68a1b7254f0c83248f20b30d3840b547