### PR TITLE
test: add dashboard e2e test

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('ダッシュボードページの表示とログアウト操作を検証する', async ({ page }) => {
+  // ページ遷移
+  await page.goto('dashboard');
+  await expect(page).toHaveURL(/.*\/dashboard/);
+
+  // 要素表示
+  await expect(page.getByRole('heading', { name: 'ダッシュボード' })).toBeVisible();
+
+  // 主要操作: ログアウトリンクの動作確認
+  await page.getByRole('link', { name: 'ログアウト' }).click();
+  await expect(page).toHaveURL(/\/login/);
+});


### PR DESCRIPTION
## Summary
- add dashboard page e2e test verifying navigation, display, and logout action

## Testing
- `npx playwright test` *(fails: connection to PostgreSQL refused)*

------
https://chatgpt.com/codex/tasks/task_b_68a1c8ffe28883248e82d7cf5a3d1c05