### PR TITLE
refactor: move column comments

### DIFF
--- a/src/main/resources/db/migration/V001__Create_Base_Tables.sql
+++ b/src/main/resources/db/migration/V001__Create_Base_Tables.sql
@@ -5,68 +5,115 @@
 -- Months table (3 months total)
 CREATE TABLE months (
     id SERIAL PRIMARY KEY,
-    month_number INTEGER NOT NULL UNIQUE CHECK (month_number >= 1 AND month_number <= 3) COMMENT '月番号（1-3の月番号）',
-    month_name VARCHAR(100) NOT NULL COMMENT '月名称（月の表示名）',
-    description TEXT COMMENT '説明（月の学習内容説明）',
-    start_date DATE COMMENT '開始日（月の開始予定日）',
-    end_date DATE COMMENT '終了日（月の終了予定日）',
-    is_active BOOLEAN DEFAULT true COMMENT '有効状態（月の使用可否）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）',
-    updated_by INTEGER REFERENCES users(id) COMMENT '更新者（レコード更新したユーザーID）'
+    month_number INTEGER NOT NULL UNIQUE CHECK (month_number >= 1 AND month_number <= 3),
+    month_name VARCHAR(100) NOT NULL,
+    description TEXT,
+    start_date DATE,
+    end_date DATE,
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN months.month_number IS '月番号（1-3の月番号）';
+COMMENT ON COLUMN months.month_name IS '月名称（月の表示名）';
+COMMENT ON COLUMN months.description IS '説明（月の学習内容説明）';
+COMMENT ON COLUMN months.start_date IS '開始日（月の開始予定日）';
+COMMENT ON COLUMN months.end_date IS '終了日（月の終了予定日）';
+COMMENT ON COLUMN months.is_active IS '有効状態（月の使用可否）';
+COMMENT ON COLUMN months.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN months.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN months.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN months.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Weeks table (18 weeks total, 6 weeks per month)
 CREATE TABLE weeks (
     id SERIAL PRIMARY KEY,
     month_id INTEGER NOT NULL REFERENCES months(id),
-    week_number INTEGER NOT NULL CHECK (week_number >= 1 AND week_number <= 18) COMMENT '週番号（1-18の週番号）',
-    week_name VARCHAR(100) NOT NULL COMMENT '週名称（週の表示名）',
-    description TEXT COMMENT '説明（週の学習内容説明）',
-    start_date DATE COMMENT '開始日（週の開始予定日）',
-    end_date DATE COMMENT '終了日（週の終了予定日）',
-    is_active BOOLEAN DEFAULT true COMMENT '有効状態（週の使用可否）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）',
-    updated_by INTEGER REFERENCES users(id) COMMENT '更新者（レコード更新したユーザーID）'
+    week_number INTEGER NOT NULL CHECK (week_number >= 1 AND week_number <= 18),
+    week_name VARCHAR(100) NOT NULL,
+    description TEXT,
+    start_date DATE,
+    end_date DATE,
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN weeks.week_number IS '週番号（1-18の週番号）';
+COMMENT ON COLUMN weeks.week_name IS '週名称（週の表示名）';
+COMMENT ON COLUMN weeks.description IS '説明（週の学習内容説明）';
+COMMENT ON COLUMN weeks.start_date IS '開始日（週の開始予定日）';
+COMMENT ON COLUMN weeks.end_date IS '終了日（週の終了予定日）';
+COMMENT ON COLUMN weeks.is_active IS '有効状態（週の使用可否）';
+COMMENT ON COLUMN weeks.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN weeks.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN weeks.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN weeks.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Days table (54 days total, 3 days per week)  
 CREATE TABLE days (
     id SERIAL PRIMARY KEY,
     week_id INTEGER NOT NULL REFERENCES weeks(id),
-    day_number INTEGER NOT NULL CHECK (day_number >= 1 AND day_number <= 54) COMMENT '日番号（1-54の日番号）',
-    day_name VARCHAR(100) NOT NULL COMMENT '日名称（日の表示名）',
-    description TEXT COMMENT '説明（日の学習内容説明）',
-    scheduled_date DATE COMMENT '予定日（日の実施予定日）',
-    is_active BOOLEAN DEFAULT true COMMENT '有効状態（日の使用可否）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）',
-    updated_by INTEGER REFERENCES users(id) COMMENT '更新者（レコード更新したユーザーID）'
+    day_number INTEGER NOT NULL CHECK (day_number >= 1 AND day_number <= 54),
+    day_name VARCHAR(100) NOT NULL,
+    description TEXT,
+    scheduled_date DATE,
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN days.day_number IS '日番号（1-54の日番号）';
+COMMENT ON COLUMN days.day_name IS '日名称（日の表示名）';
+COMMENT ON COLUMN days.description IS '説明（日の学習内容説明）';
+COMMENT ON COLUMN days.scheduled_date IS '予定日（日の実施予定日）';
+COMMENT ON COLUMN days.is_active IS '有効状態（日の使用可否）';
+COMMENT ON COLUMN days.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN days.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN days.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN days.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Lectures table (54 lectures total, 1 lecture per day)
 CREATE TABLE lectures (
     id SERIAL PRIMARY KEY,
     day_id INTEGER NOT NULL REFERENCES days(id),
-    lecture_number INTEGER NOT NULL UNIQUE CHECK (lecture_number >= 1 AND lecture_number <= 54) COMMENT '講義番号（1-54の講義番号）',
-    lecture_title VARCHAR(200) NOT NULL COMMENT '講義タイトル（講義の題名）',
-    description TEXT COMMENT '説明（講義の詳細説明）',
-    goals JSON COMMENT '学習目標（講義の学習目標リスト）',
-    content_chapters JSON COMMENT '章構成（講義の章立てリスト）',
-    content_blocks JSON COMMENT '内容ブロック（講義の詳細内容ブロックリスト）',
-    estimated_duration INTEGER DEFAULT 180 COMMENT '予定時間（講義の予定時間（分））',
-    materials_url TEXT COMMENT '教材URL（講義教材のURL）',
-    video_url TEXT COMMENT '動画URL（講義動画のURL）',
-    is_active BOOLEAN DEFAULT true COMMENT '有効状態（講義の使用可否）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）',
-    updated_by INTEGER REFERENCES users(id) COMMENT '更新者（レコード更新したユーザーID）'
+    lecture_number INTEGER NOT NULL UNIQUE CHECK (lecture_number >= 1 AND lecture_number <= 54),
+    lecture_title VARCHAR(200) NOT NULL,
+    description TEXT,
+    goals JSON,
+    content_chapters JSON,
+    content_blocks JSON,
+    estimated_duration INTEGER DEFAULT 180,
+    materials_url TEXT,
+    video_url TEXT,
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN lectures.lecture_number IS '講義番号（1-54の講義番号）';
+COMMENT ON COLUMN lectures.lecture_title IS '講義タイトル（講義の題名）';
+COMMENT ON COLUMN lectures.description IS '説明（講義の詳細説明）';
+COMMENT ON COLUMN lectures.goals IS '学習目標（講義の学習目標リスト）';
+COMMENT ON COLUMN lectures.content_chapters IS '章構成（講義の章立てリスト）';
+COMMENT ON COLUMN lectures.content_blocks IS '内容ブロック（講義の詳細内容ブロックリスト）';
+COMMENT ON COLUMN lectures.estimated_duration IS '予定時間（講義の予定時間（分））';
+COMMENT ON COLUMN lectures.materials_url IS '教材URL（講義教材のURL）';
+COMMENT ON COLUMN lectures.video_url IS '動画URL（講義動画のURL）';
+COMMENT ON COLUMN lectures.is_active IS '有効状態（講義の使用可否）';
+COMMENT ON COLUMN lectures.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN lectures.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN lectures.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN lectures.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Performance indexes
 CREATE INDEX idx_weeks_month ON weeks(month_id);

--- a/src/main/resources/db/migration/V002__Create_Training_Management_Tables.sql
+++ b/src/main/resources/db/migration/V002__Create_Training_Management_Tables.sql
@@ -5,99 +5,165 @@
 -- Training Programs (course definitions that can be copied/reused)
 CREATE TABLE training_programs (
     id SERIAL PRIMARY KEY,
-    program_name VARCHAR(200) NOT NULL COMMENT 'プログラム名（研修プログラムの名称）',
-    description TEXT COMMENT '説明（プログラムの詳細説明）',
-    company_id INTEGER REFERENCES companies(id) COMMENT '会社ID（プログラムを実施する会社）',
-    duration_months INTEGER DEFAULT 3 CHECK (duration_months > 0) COMMENT '期間月数（プログラムの実施期間）',
-    max_students INTEGER DEFAULT 30 CHECK (max_students > 0) COMMENT '最大受講者数（プログラムの定員）',
-    is_template BOOLEAN DEFAULT false COMMENT 'テンプレート（他社コピー用テンプレートか）',
-    is_active BOOLEAN DEFAULT true COMMENT '有効状態（プログラムの使用可否）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）',
-    updated_by INTEGER REFERENCES users(id) COMMENT '更新者（レコード更新したユーザーID）'
+    program_name VARCHAR(200) NOT NULL,
+    description TEXT,
+    company_id INTEGER REFERENCES companies(id),
+    duration_months INTEGER DEFAULT 3 CHECK (duration_months > 0),
+    max_students INTEGER DEFAULT 30 CHECK (max_students > 0),
+    is_template BOOLEAN DEFAULT false,
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN training_programs.program_name IS 'プログラム名（研修プログラムの名称）';
+COMMENT ON COLUMN training_programs.description IS '説明（プログラムの詳細説明）';
+COMMENT ON COLUMN training_programs.company_id IS '会社ID（プログラムを実施する会社）';
+COMMENT ON COLUMN training_programs.duration_months IS '期間月数（プログラムの実施期間）';
+COMMENT ON COLUMN training_programs.max_students IS '最大受講者数（プログラムの定員）';
+COMMENT ON COLUMN training_programs.is_template IS 'テンプレート（他社コピー用テンプレートか）';
+COMMENT ON COLUMN training_programs.is_active IS '有効状態（プログラムの使用可否）';
+COMMENT ON COLUMN training_programs.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN training_programs.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN training_programs.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN training_programs.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Training Schedules (specific scheduled instances of programs)
 CREATE TABLE training_schedules (
     id SERIAL PRIMARY KEY,
     training_program_id INTEGER NOT NULL REFERENCES training_programs(id),
-    schedule_name VARCHAR(200) NOT NULL COMMENT 'スケジュール名（実施スケジュールの名称）',
-    start_date DATE NOT NULL COMMENT '開始日（研修開始日）',
-    end_date DATE NOT NULL COMMENT '終了日（研修終了日）',
-    instructor_id INTEGER REFERENCES users(id) COMMENT '講師ID（メイン講師のユーザーID）',
-    status VARCHAR(20) DEFAULT 'planned' CHECK (status IN ('planned', 'active', 'completed', 'cancelled')) COMMENT 'ステータス（スケジュールの状態）',
-    actual_students INTEGER DEFAULT 0 COMMENT '実際受講者数（実際の参加者数）',
-    notes TEXT COMMENT '備考（スケジュールの備考情報）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）',
-    updated_by INTEGER REFERENCES users(id) COMMENT '更新者（レコード更新したユーザーID）'
+    schedule_name VARCHAR(200) NOT NULL,
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    instructor_id INTEGER REFERENCES users(id),
+    status VARCHAR(20) DEFAULT 'planned' CHECK (status IN ('planned', 'active', 'completed', 'cancelled')),
+    actual_students INTEGER DEFAULT 0,
+    notes TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN training_schedules.schedule_name IS 'スケジュール名（実施スケジュールの名称）';
+COMMENT ON COLUMN training_schedules.start_date IS '開始日（研修開始日）';
+COMMENT ON COLUMN training_schedules.end_date IS '終了日（研修終了日）';
+COMMENT ON COLUMN training_schedules.instructor_id IS '講師ID（メイン講師のユーザーID）';
+COMMENT ON COLUMN training_schedules.status IS 'ステータス（スケジュールの状態）';
+COMMENT ON COLUMN training_schedules.actual_students IS '実際受講者数（実際の参加者数）';
+COMMENT ON COLUMN training_schedules.notes IS '備考（スケジュールの備考情報）';
+COMMENT ON COLUMN training_schedules.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN training_schedules.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN training_schedules.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN training_schedules.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Instructors (extends users table for instructor-specific information)
 CREATE TABLE instructors (
     id SERIAL PRIMARY KEY,
     user_id INTEGER NOT NULL UNIQUE REFERENCES users(id),
-    instructor_code VARCHAR(50) UNIQUE COMMENT '講師コード（講師の識別コード）',
-    specialties JSON COMMENT '専門分野（講師の専門分野リスト）',
-    bio TEXT COMMENT '経歴（講師の経歴・プロフィール）',
-    certifications JSON COMMENT '資格（講師の保有資格リスト）',
-    hourly_rate DECIMAL(10,2) COMMENT '時間単価（講師の時間あたり報酬）',
-    is_active BOOLEAN DEFAULT true COMMENT '有効状態（講師の活動状態）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）',
-    updated_by INTEGER REFERENCES users(id) COMMENT '更新者（レコード更新したユーザーID）'
+    instructor_code VARCHAR(50) UNIQUE,
+    specialties JSON,
+    bio TEXT,
+    certifications JSON,
+    hourly_rate DECIMAL(10,2),
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN instructors.instructor_code IS '講師コード（講師の識別コード）';
+COMMENT ON COLUMN instructors.specialties IS '専門分野（講師の専門分野リスト）';
+COMMENT ON COLUMN instructors.bio IS '経歴（講師の経歴・プロフィール）';
+COMMENT ON COLUMN instructors.certifications IS '資格（講師の保有資格リスト）';
+COMMENT ON COLUMN instructors.hourly_rate IS '時間単価（講師の時間あたり報酬）';
+COMMENT ON COLUMN instructors.is_active IS '有効状態（講師の活動状態）';
+COMMENT ON COLUMN instructors.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN instructors.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN instructors.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN instructors.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Students (extends users table for student-specific information)
 CREATE TABLE students (
     id SERIAL PRIMARY KEY,
     user_id INTEGER NOT NULL UNIQUE REFERENCES users(id),
-    student_code VARCHAR(50) UNIQUE COMMENT '受講者コード（受講者の識別コード）',
-    company_id INTEGER REFERENCES companies(id) COMMENT '所属会社ID（受講者の所属会社）',
-    department VARCHAR(100) COMMENT '部署（受講者の所属部署）',
-    position VARCHAR(100) COMMENT '役職（受講者の役職）',
-    experience_years INTEGER DEFAULT 0 CHECK (experience_years >= 0) COMMENT '経験年数（プログラミング経験年数）',
-    education_background VARCHAR(200) COMMENT '学歴（受講者の学歴）',
-    motivation TEXT COMMENT '受講動機（受講の動機・目標）',
-    is_active BOOLEAN DEFAULT true COMMENT '有効状態（受講者の活動状態）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）',
-    updated_by INTEGER REFERENCES users(id) COMMENT '更新者（レコード更新したユーザーID）'
+    student_code VARCHAR(50) UNIQUE,
+    company_id INTEGER REFERENCES companies(id),
+    department VARCHAR(100),
+    position VARCHAR(100),
+    experience_years INTEGER DEFAULT 0 CHECK (experience_years >= 0),
+    education_background VARCHAR(200),
+    motivation TEXT,
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN students.student_code IS '受講者コード（受講者の識別コード）';
+COMMENT ON COLUMN students.company_id IS '所属会社ID（受講者の所属会社）';
+COMMENT ON COLUMN students.department IS '部署（受講者の所属部署）';
+COMMENT ON COLUMN students.position IS '役職（受講者の役職）';
+COMMENT ON COLUMN students.experience_years IS '経験年数（プログラミング経験年数）';
+COMMENT ON COLUMN students.education_background IS '学歴（受講者の学歴）';
+COMMENT ON COLUMN students.motivation IS '受講動機（受講の動機・目標）';
+COMMENT ON COLUMN students.is_active IS '有効状態（受講者の活動状態）';
+COMMENT ON COLUMN students.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN students.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN students.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN students.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Training Assignments (assigns students to specific training schedules)
 CREATE TABLE training_assignments (
     id SERIAL PRIMARY KEY,
     training_schedule_id INTEGER NOT NULL REFERENCES training_schedules(id),
     student_id INTEGER NOT NULL REFERENCES students(id),
-    assignment_date DATE DEFAULT CURRENT_DATE COMMENT '配属日（研修への配属日）',
-    status VARCHAR(20) DEFAULT 'assigned' CHECK (status IN ('assigned', 'active', 'completed', 'dropped', 'transferred')) COMMENT 'ステータス（配属の状態）',
-    completion_date DATE COMMENT '完了日（研修完了日）',
-    final_score DECIMAL(5,2) COMMENT '最終得点（研修の最終得点）',
-    certificate_issued BOOLEAN DEFAULT false COMMENT '修了証発行（修了証の発行可否）',
-    notes TEXT COMMENT '備考（配属に関する備考）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）',
-    updated_by INTEGER REFERENCES users(id) COMMENT '更新者（レコード更新したユーザーID）'
+    assignment_date DATE DEFAULT CURRENT_DATE,
+    status VARCHAR(20) DEFAULT 'assigned' CHECK (status IN ('assigned', 'active', 'completed', 'dropped', 'transferred')),
+    completion_date DATE,
+    final_score DECIMAL(5,2),
+    certificate_issued BOOLEAN DEFAULT false,
+    notes TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN training_assignments.assignment_date IS '配属日（研修への配属日）';
+COMMENT ON COLUMN training_assignments.status IS 'ステータス（配属の状態）';
+COMMENT ON COLUMN training_assignments.completion_date IS '完了日（研修完了日）';
+COMMENT ON COLUMN training_assignments.final_score IS '最終得点（研修の最終得点）';
+COMMENT ON COLUMN training_assignments.certificate_issued IS '修了証発行（修了証の発行可否）';
+COMMENT ON COLUMN training_assignments.notes IS '備考（配属に関する備考）';
+COMMENT ON COLUMN training_assignments.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN training_assignments.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN training_assignments.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN training_assignments.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Schedule Instructors (allows multiple instructors per schedule)
 CREATE TABLE schedule_instructors (
     id SERIAL PRIMARY KEY,
     training_schedule_id INTEGER NOT NULL REFERENCES training_schedules(id),
     instructor_id INTEGER NOT NULL REFERENCES instructors(id),
-    role VARCHAR(50) DEFAULT 'assistant' CHECK (role IN ('main', 'assistant', 'guest')) COMMENT '役割（講師の役割）',
-    assigned_lectures JSON COMMENT '担当講義（担当する講義のリスト）',
-    start_date DATE COMMENT '開始日（担当開始日）',
-    end_date DATE COMMENT '終了日（担当終了日）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）'
+    role VARCHAR(50) DEFAULT 'assistant' CHECK (role IN ('main', 'assistant', 'guest')),
+    assigned_lectures JSON,
+    start_date DATE,
+    end_date DATE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN schedule_instructors.role IS '役割（講師の役割）';
+COMMENT ON COLUMN schedule_instructors.assigned_lectures IS '担当講義（担当する講義のリスト）';
+COMMENT ON COLUMN schedule_instructors.start_date IS '開始日（担当開始日）';
+COMMENT ON COLUMN schedule_instructors.end_date IS '終了日（担当終了日）';
+COMMENT ON COLUMN schedule_instructors.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN schedule_instructors.created_by IS '作成者（レコード作成したユーザーID）';
 
 -- Performance indexes for optimization
 CREATE INDEX idx_training_programs_company ON training_programs(company_id);

--- a/src/main/resources/db/migration/V003__Create_Question_And_Grade_Tables.sql
+++ b/src/main/resources/db/migration/V003__Create_Question_And_Grade_Tables.sql
@@ -7,68 +7,114 @@ CREATE TABLE exercise_question_bank (
     id SERIAL PRIMARY KEY,
     lecture_id INTEGER NOT NULL REFERENCES lectures(id),
     question_type VARCHAR(20) NOT NULL CHECK (question_type IN ('multiple_choice', 'essay', 'code', 'fill_blank')),
-    question_text TEXT NOT NULL COMMENT '問題文（演習問題の内容）',
-    question_options JSON COMMENT '選択肢（多択問題の場合）',
-    correct_answer TEXT COMMENT '正解（多択・穴埋め問題の正答）',
-    answer_explanation TEXT COMMENT '解説（問題の解答説明）',
-    difficulty_level INTEGER DEFAULT 1 CHECK (difficulty_level BETWEEN 1 AND 5) COMMENT '難易度（1-5の5段階評価）',
-    points INTEGER DEFAULT 5 CHECK (points > 0) COMMENT '配点（問題の得点）',
-    is_active BOOLEAN DEFAULT true COMMENT '有効状態（問題の使用可否）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）',
-    updated_by INTEGER REFERENCES users(id) COMMENT '更新者（レコード更新したユーザーID）'
+    question_text TEXT NOT NULL,
+    question_options JSON,
+    correct_answer TEXT,
+    answer_explanation TEXT,
+    difficulty_level INTEGER DEFAULT 1 CHECK (difficulty_level BETWEEN 1 AND 5),
+    points INTEGER DEFAULT 5 CHECK (points > 0),
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN exercise_question_bank.question_text IS '問題文（演習問題の内容）';
+COMMENT ON COLUMN exercise_question_bank.question_options IS '選択肢（多択問題の場合）';
+COMMENT ON COLUMN exercise_question_bank.correct_answer IS '正解（多択・穴埋め問題の正答）';
+COMMENT ON COLUMN exercise_question_bank.answer_explanation IS '解説（問題の解答説明）';
+COMMENT ON COLUMN exercise_question_bank.difficulty_level IS '難易度（1-5の5段階評価）';
+COMMENT ON COLUMN exercise_question_bank.points IS '配点（問題の得点）';
+COMMENT ON COLUMN exercise_question_bank.is_active IS '有効状態（問題の使用可否）';
+COMMENT ON COLUMN exercise_question_bank.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN exercise_question_bank.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN exercise_question_bank.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN exercise_question_bank.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Quiz Question Bank (per lecture)
 CREATE TABLE quiz_question_bank (
     id SERIAL PRIMARY KEY,
     lecture_id INTEGER NOT NULL REFERENCES lectures(id),
     question_type VARCHAR(20) NOT NULL CHECK (question_type IN ('multiple_choice', 'true_false', 'short_answer')),
-    question_text TEXT NOT NULL COMMENT '問題文（クイズ問題の内容）',
-    question_options JSON COMMENT '選択肢（多択問題の場合）',
-    correct_answer TEXT NOT NULL COMMENT '正解（クイズ問題の正答）',
-    answer_explanation TEXT COMMENT '解説（問題の解答説明）',
-    time_limit INTEGER DEFAULT 60 COMMENT '制限時間（秒単位）',
-    points INTEGER DEFAULT 10 CHECK (points > 0) COMMENT '配点（問題の得点）',
-    is_active BOOLEAN DEFAULT true COMMENT '有効状態（問題の使用可否）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）',
-    updated_by INTEGER REFERENCES users(id) COMMENT '更新者（レコード更新したユーザーID）'
+    question_text TEXT NOT NULL,
+    question_options JSON,
+    correct_answer TEXT NOT NULL,
+    answer_explanation TEXT,
+    time_limit INTEGER DEFAULT 60,
+    points INTEGER DEFAULT 10 CHECK (points > 0),
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN quiz_question_bank.question_text IS '問題文（クイズ問題の内容）';
+COMMENT ON COLUMN quiz_question_bank.question_options IS '選択肢（多択問題の場合）';
+COMMENT ON COLUMN quiz_question_bank.correct_answer IS '正解（クイズ問題の正答）';
+COMMENT ON COLUMN quiz_question_bank.answer_explanation IS '解説（問題の解答説明）';
+COMMENT ON COLUMN quiz_question_bank.time_limit IS '制限時間（秒単位）';
+COMMENT ON COLUMN quiz_question_bank.points IS '配点（問題の得点）';
+COMMENT ON COLUMN quiz_question_bank.is_active IS '有効状態（問題の使用可否）';
+COMMENT ON COLUMN quiz_question_bank.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN quiz_question_bank.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN quiz_question_bank.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN quiz_question_bank.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Mock Test Question Bank (comprehensive assessment)
 CREATE TABLE mock_test_bank (
     id SERIAL PRIMARY KEY,
-    test_name VARCHAR(200) NOT NULL COMMENT 'テスト名（模擬試験の名称）',
-    description TEXT COMMENT '説明（テストの詳細説明）',
-    duration_minutes INTEGER DEFAULT 120 COMMENT '試験時間（分単位）',
-    total_points INTEGER DEFAULT 100 COMMENT '総得点（テストの満点）',
-    passing_score INTEGER DEFAULT 60 COMMENT '合格点（合格に必要な得点）',
-    is_active BOOLEAN DEFAULT true COMMENT '有効状態（テストの使用可否）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）',
-    updated_by INTEGER REFERENCES users(id) COMMENT '更新者（レコード更新したユーザーID）'
+    test_name VARCHAR(200) NOT NULL,
+    description TEXT,
+    duration_minutes INTEGER DEFAULT 120,
+    total_points INTEGER DEFAULT 100,
+    passing_score INTEGER DEFAULT 60,
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN mock_test_bank.test_name IS 'テスト名（模擬試験の名称）';
+COMMENT ON COLUMN mock_test_bank.description IS '説明（テストの詳細説明）';
+COMMENT ON COLUMN mock_test_bank.duration_minutes IS '試験時間（分単位）';
+COMMENT ON COLUMN mock_test_bank.total_points IS '総得点（テストの満点）';
+COMMENT ON COLUMN mock_test_bank.passing_score IS '合格点（合格に必要な得点）';
+COMMENT ON COLUMN mock_test_bank.is_active IS '有効状態（テストの使用可否）';
+COMMENT ON COLUMN mock_test_bank.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN mock_test_bank.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN mock_test_bank.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN mock_test_bank.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Mock Test Questions (links to question bank)
 CREATE TABLE mock_test_questions (
     id SERIAL PRIMARY KEY,
     mock_test_id INTEGER NOT NULL REFERENCES mock_test_bank(id),
     question_type VARCHAR(20) NOT NULL CHECK (question_type IN ('multiple_choice', 'essay', 'code', 'true_false')),
-    question_text TEXT NOT NULL COMMENT '問題文（模擬試験問題の内容）',
-    question_options JSON COMMENT '選択肢（多択問題の場合）',
-    correct_answer TEXT COMMENT '正解（問題の正答）',
-    answer_explanation TEXT COMMENT '解説（問題の解答説明）',
-    points INTEGER DEFAULT 5 CHECK (points > 0) COMMENT '配点（問題の得点）',
-    question_order INTEGER NOT NULL COMMENT '問題順序（テスト内での順番）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）',
-    updated_by INTEGER REFERENCES users(id) COMMENT '更新者（レコード更新したユーザーID）'
+    question_text TEXT NOT NULL,
+    question_options JSON,
+    correct_answer TEXT,
+    answer_explanation TEXT,
+    points INTEGER DEFAULT 5 CHECK (points > 0),
+    question_order INTEGER NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN mock_test_questions.question_text IS '問題文（模擬試験問題の内容）';
+COMMENT ON COLUMN mock_test_questions.question_options IS '選択肢（多択問題の場合）';
+COMMENT ON COLUMN mock_test_questions.correct_answer IS '正解（問題の正答）';
+COMMENT ON COLUMN mock_test_questions.answer_explanation IS '解説（問題の解答説明）';
+COMMENT ON COLUMN mock_test_questions.points IS '配点（問題の得点）';
+COMMENT ON COLUMN mock_test_questions.question_order IS '問題順序（テスト内での順番）';
+COMMENT ON COLUMN mock_test_questions.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN mock_test_questions.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN mock_test_questions.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN mock_test_questions.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Exercise Submissions (student exercise attempts)
 CREATE TABLE exercise_submissions (
@@ -76,14 +122,22 @@ CREATE TABLE exercise_submissions (
     training_assignment_id INTEGER NOT NULL REFERENCES training_assignments(id),
     lecture_id INTEGER NOT NULL REFERENCES lectures(id),
     question_id INTEGER NOT NULL REFERENCES exercise_question_bank(id),
-    student_answer TEXT COMMENT '解答（学生の回答内容）',
-    is_correct BOOLEAN COMMENT '正誤（回答の正誤判定）',
-    points_earned INTEGER DEFAULT 0 COMMENT '獲得点（得られた得点）',
-    submission_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '提出時刻（解答提出時刻）',
-    graded_at TIMESTAMP COMMENT '採点時刻（採点完了時刻）',
-    graded_by INTEGER REFERENCES users(id) COMMENT '採点者（採点したユーザーID）',
-    feedback TEXT COMMENT 'フィードバック（採点者からのコメント）'
+    student_answer TEXT,
+    is_correct BOOLEAN,
+    points_earned INTEGER DEFAULT 0,
+    submission_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    graded_at TIMESTAMP,
+    graded_by INTEGER REFERENCES users(id),
+    feedback TEXT
 );
+
+COMMENT ON COLUMN exercise_submissions.student_answer IS '解答（学生の回答内容）';
+COMMENT ON COLUMN exercise_submissions.is_correct IS '正誤（回答の正誤判定）';
+COMMENT ON COLUMN exercise_submissions.points_earned IS '獲得点（得られた得点）';
+COMMENT ON COLUMN exercise_submissions.submission_time IS '提出時刻（解答提出時刻）';
+COMMENT ON COLUMN exercise_submissions.graded_at IS '採点時刻（採点完了時刻）';
+COMMENT ON COLUMN exercise_submissions.graded_by IS '採点者（採点したユーザーID）';
+COMMENT ON COLUMN exercise_submissions.feedback IS 'フィードバック（採点者からのコメント）';
 
 -- Quiz Submissions (student quiz attempts)
 CREATE TABLE quiz_submissions (
@@ -91,93 +145,153 @@ CREATE TABLE quiz_submissions (
     training_assignment_id INTEGER NOT NULL REFERENCES training_assignments(id),
     lecture_id INTEGER NOT NULL REFERENCES lectures(id),
     question_id INTEGER NOT NULL REFERENCES quiz_question_bank(id),
-    student_answer TEXT NOT NULL COMMENT '解答（学生の回答内容）',
-    is_correct BOOLEAN NOT NULL COMMENT '正誤（回答の正誤判定）',
-    points_earned INTEGER DEFAULT 0 COMMENT '獲得点（得られた得点）',
-    time_taken INTEGER COMMENT '回答時間（秒単位）',
-    submission_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '提出時刻（解答提出時刻）'
+    student_answer TEXT NOT NULL,
+    is_correct BOOLEAN NOT NULL,
+    points_earned INTEGER DEFAULT 0,
+    time_taken INTEGER,
+    submission_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+COMMENT ON COLUMN quiz_submissions.student_answer IS '解答（学生の回答内容）';
+COMMENT ON COLUMN quiz_submissions.is_correct IS '正誤（回答の正誤判定）';
+COMMENT ON COLUMN quiz_submissions.points_earned IS '獲得点（得られた得点）';
+COMMENT ON COLUMN quiz_submissions.time_taken IS '回答時間（秒単位）';
+COMMENT ON COLUMN quiz_submissions.submission_time IS '提出時刻（解答提出時刻）';
 
 -- Mock Test Submissions (student mock test attempts)
 CREATE TABLE mock_test_submissions (
     id SERIAL PRIMARY KEY,
     training_assignment_id INTEGER NOT NULL REFERENCES training_assignments(id),
     mock_test_id INTEGER NOT NULL REFERENCES mock_test_bank(id),
-    start_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '開始時刻（テスト開始時刻）',
-    end_time TIMESTAMP COMMENT '終了時刻（テスト終了時刻）',
-    total_score INTEGER DEFAULT 0 COMMENT '総得点（テストの総得点）',
-    is_passed BOOLEAN COMMENT '合格状態（合格可否）',
-    is_completed BOOLEAN DEFAULT false COMMENT '完了状態（テスト完了可否）',
-    submission_time TIMESTAMP COMMENT '提出時刻（テスト提出時刻）'
+    start_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    end_time TIMESTAMP,
+    total_score INTEGER DEFAULT 0,
+    is_passed BOOLEAN,
+    is_completed BOOLEAN DEFAULT false,
+    submission_time TIMESTAMP
 );
+
+COMMENT ON COLUMN mock_test_submissions.start_time IS '開始時刻（テスト開始時刻）';
+COMMENT ON COLUMN mock_test_submissions.end_time IS '終了時刻（テスト終了時刻）';
+COMMENT ON COLUMN mock_test_submissions.total_score IS '総得点（テストの総得点）';
+COMMENT ON COLUMN mock_test_submissions.is_passed IS '合格状態（合格可否）';
+COMMENT ON COLUMN mock_test_submissions.is_completed IS '完了状態（テスト完了可否）';
+COMMENT ON COLUMN mock_test_submissions.submission_time IS '提出時刻（テスト提出時刻）';
 
 -- Mock Test Question Answers (individual question responses)
 CREATE TABLE mock_test_answers (
     id SERIAL PRIMARY KEY,
     mock_test_submission_id INTEGER NOT NULL REFERENCES mock_test_submissions(id),
     question_id INTEGER NOT NULL REFERENCES mock_test_questions(id),
-    student_answer TEXT COMMENT '解答（学生の回答内容）',
-    is_correct BOOLEAN COMMENT '正誤（回答の正誤判定）',
-    points_earned INTEGER DEFAULT 0 COMMENT '獲得点（得られた得点）',
-    answer_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '回答時刻（問題回答時刻）',
-    graded_at TIMESTAMP COMMENT '採点時刻（採点完了時刻）',
-    graded_by INTEGER REFERENCES users(id) COMMENT '採点者（採点したユーザーID）',
-    feedback TEXT COMMENT 'フィードバック（採点者からのコメント）'
+    student_answer TEXT,
+    is_correct BOOLEAN,
+    points_earned INTEGER DEFAULT 0,
+    answer_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    graded_at TIMESTAMP,
+    graded_by INTEGER REFERENCES users(id),
+    feedback TEXT
 );
+
+COMMENT ON COLUMN mock_test_answers.student_answer IS '解答（学生の回答内容）';
+COMMENT ON COLUMN mock_test_answers.is_correct IS '正誤（回答の正誤判定）';
+COMMENT ON COLUMN mock_test_answers.points_earned IS '獲得点（得られた得点）';
+COMMENT ON COLUMN mock_test_answers.answer_time IS '回答時刻（問題回答時刻）';
+COMMENT ON COLUMN mock_test_answers.graded_at IS '採点時刻（採点完了時刻）';
+COMMENT ON COLUMN mock_test_answers.graded_by IS '採点者（採点したユーザーID）';
+COMMENT ON COLUMN mock_test_answers.feedback IS 'フィードバック（採点者からのコメント）';
 
 -- Lecture Grades (per lecture assessment summary)
 CREATE TABLE lecture_grades (
     id SERIAL PRIMARY KEY,
     training_assignment_id INTEGER NOT NULL REFERENCES training_assignments(id),
     lecture_id INTEGER NOT NULL REFERENCES lectures(id),
-    exercise_score INTEGER DEFAULT 0 COMMENT '演習得点（演習問題の合計得点）',
-    exercise_max_score INTEGER DEFAULT 100 COMMENT '演習満点（演習問題の満点）',
-    quiz_score INTEGER DEFAULT 0 COMMENT 'クイズ得点（クイズの合計得点）',
-    quiz_max_score INTEGER DEFAULT 100 COMMENT 'クイズ満点（クイズの満点）',
-    attendance_status VARCHAR(20) DEFAULT 'absent' CHECK (attendance_status IN ('present', 'absent', 'late', 'excused')) COMMENT '出席状況（出席の状態）',
-    completion_status VARCHAR(20) DEFAULT 'not_started' CHECK (completion_status IN ('not_started', 'in_progress', 'completed')) COMMENT '完了状況（講義の進捗状態）',
-    completion_date TIMESTAMP COMMENT '完了日時（講義完了時刻）',
-    grade_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '採点日時（成績記録時刻）',
-    instructor_feedback TEXT COMMENT '講師コメント（講師からのフィードバック）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）'
+    exercise_score INTEGER DEFAULT 0,
+    exercise_max_score INTEGER DEFAULT 100,
+    quiz_score INTEGER DEFAULT 0,
+    quiz_max_score INTEGER DEFAULT 100,
+    attendance_status VARCHAR(20) DEFAULT 'absent' CHECK (attendance_status IN ('present', 'absent', 'late', 'excused')),
+    completion_status VARCHAR(20) DEFAULT 'not_started' CHECK (completion_status IN ('not_started', 'in_progress', 'completed')),
+    completion_date TIMESTAMP,
+    grade_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    instructor_feedback TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+COMMENT ON COLUMN lecture_grades.exercise_score IS '演習得点（演習問題の合計得点）';
+COMMENT ON COLUMN lecture_grades.exercise_max_score IS '演習満点（演習問題の満点）';
+COMMENT ON COLUMN lecture_grades.quiz_score IS 'クイズ得点（クイズの合計得点）';
+COMMENT ON COLUMN lecture_grades.quiz_max_score IS 'クイズ満点（クイズの満点）';
+COMMENT ON COLUMN lecture_grades.attendance_status IS '出席状況（出席の状態）';
+COMMENT ON COLUMN lecture_grades.completion_status IS '完了状況（講義の進捗状態）';
+COMMENT ON COLUMN lecture_grades.completion_date IS '完了日時（講義完了時刻）';
+COMMENT ON COLUMN lecture_grades.grade_date IS '採点日時（成績記録時刻）';
+COMMENT ON COLUMN lecture_grades.instructor_feedback IS '講師コメント（講師からのフィードバック）';
+COMMENT ON COLUMN lecture_grades.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN lecture_grades.updated_at IS '更新日時（レコード更新時刻）';
 
 -- Student Grade Summaries (overall progress tracking)
 CREATE TABLE student_grade_summaries (
     id SERIAL PRIMARY KEY,
     training_assignment_id INTEGER NOT NULL REFERENCES training_assignments(id),
-    total_exercise_score INTEGER DEFAULT 0 COMMENT '演習総得点（全演習問題の合計得点）',
-    total_exercise_max_score INTEGER DEFAULT 0 COMMENT '演習総満点（全演習問題の満点）',
-    total_quiz_score INTEGER DEFAULT 0 COMMENT 'クイズ総得点（全クイズの合計得点）',
-    total_quiz_max_score INTEGER DEFAULT 0 COMMENT 'クイズ総満点（全クイズの満点）',
-    mock_test_best_score INTEGER DEFAULT 0 COMMENT '模擬試験最高得点（模擬試験の最高得点）',
-    mock_test_max_score INTEGER DEFAULT 100 COMMENT '模擬試験満点（模擬試験の満点）',
-    final_grade NUMERIC(5,2) COMMENT '最終成績（40%演習+30%クイズ+30%模擬試験）',
-    grade_letter VARCHAR(2) COMMENT '成績評価（A、B、C、D、Fの評価）',
-    lectures_completed INTEGER DEFAULT 0 COMMENT '完了講義数（完了した講義の数）',
-    total_lectures INTEGER DEFAULT 54 COMMENT '総講義数（全講義の数）',
-    attendance_rate NUMERIC(5,2) COMMENT '出席率（出席講義数/総講義数）',
-    progress_percentage NUMERIC(5,2) COMMENT '進捗率（完了度のパーセンテージ）',
-    last_activity_date TIMESTAMP COMMENT '最終活動日（最後の学習活動日時）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）'
+    total_exercise_score INTEGER DEFAULT 0,
+    total_exercise_max_score INTEGER DEFAULT 0,
+    total_quiz_score INTEGER DEFAULT 0,
+    total_quiz_max_score INTEGER DEFAULT 0,
+    mock_test_best_score INTEGER DEFAULT 0,
+    mock_test_max_score INTEGER DEFAULT 100,
+    final_grade NUMERIC(5,2),
+    grade_letter VARCHAR(2),
+    lectures_completed INTEGER DEFAULT 0,
+    total_lectures INTEGER DEFAULT 54,
+    attendance_rate NUMERIC(5,2),
+    progress_percentage NUMERIC(5,2),
+    last_activity_date TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+COMMENT ON COLUMN student_grade_summaries.total_exercise_score IS '演習総得点（全演習問題の合計得点）';
+COMMENT ON COLUMN student_grade_summaries.total_exercise_max_score IS '演習総満点（全演習問題の満点）';
+COMMENT ON COLUMN student_grade_summaries.total_quiz_score IS 'クイズ総得点（全クイズの合計得点）';
+COMMENT ON COLUMN student_grade_summaries.total_quiz_max_score IS 'クイズ総満点（全クイズの満点）';
+COMMENT ON COLUMN student_grade_summaries.mock_test_best_score IS '模擬試験最高得点（模擬試験の最高得点）';
+COMMENT ON COLUMN student_grade_summaries.mock_test_max_score IS '模擬試験満点（模擬試験の満点）';
+COMMENT ON COLUMN student_grade_summaries.final_grade IS '最終成績（40%演習+30%クイズ+30%模擬試験）';
+COMMENT ON COLUMN student_grade_summaries.grade_letter IS '成績評価（A、B、C、D、Fの評価）';
+COMMENT ON COLUMN student_grade_summaries.lectures_completed IS '完了講義数（完了した講義の数）';
+COMMENT ON COLUMN student_grade_summaries.total_lectures IS '総講義数（全講義の数）';
+COMMENT ON COLUMN student_grade_summaries.attendance_rate IS '出席率（出席講義数/総講義数）';
+COMMENT ON COLUMN student_grade_summaries.progress_percentage IS '進捗率（完了度のパーセンテージ）';
+COMMENT ON COLUMN student_grade_summaries.last_activity_date IS '最終活動日（最後の学習活動日時）';
+COMMENT ON COLUMN student_grade_summaries.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN student_grade_summaries.updated_at IS '更新日時（レコード更新時刻）';
 
 -- Grade Calculation Settings (configurable scoring weights)
 CREATE TABLE grade_settings (
     id SERIAL PRIMARY KEY,
-    setting_name VARCHAR(100) NOT NULL UNIQUE COMMENT '設定名（成績設定の名称）',
-    exercise_weight NUMERIC(3,2) DEFAULT 0.40 CHECK (exercise_weight BETWEEN 0 AND 1) COMMENT '演習比重（演習問題の重み）',
-    quiz_weight NUMERIC(3,2) DEFAULT 0.30 CHECK (quiz_weight BETWEEN 0 AND 1) COMMENT 'クイズ比重（クイズの重み）',
-    mock_test_weight NUMERIC(3,2) DEFAULT 0.30 CHECK (mock_test_weight BETWEEN 0 AND 1) COMMENT '模擬試験比重（模擬試験の重み）',
-    passing_threshold NUMERIC(5,2) DEFAULT 60.00 COMMENT '合格閾値（合格に必要な得点）',
-    is_active BOOLEAN DEFAULT true COMMENT '有効状態（設定の使用可否）',
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時（レコード作成時刻）',
-    created_by INTEGER REFERENCES users(id) COMMENT '作成者（レコード作成したユーザーID）',
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '更新日時（レコード更新時刻）',
-    updated_by INTEGER REFERENCES users(id) COMMENT '更新者（レコード更新したユーザーID）'
+    setting_name VARCHAR(100) NOT NULL UNIQUE,
+    exercise_weight NUMERIC(3,2) DEFAULT 0.40 CHECK (exercise_weight BETWEEN 0 AND 1),
+    quiz_weight NUMERIC(3,2) DEFAULT 0.30 CHECK (quiz_weight BETWEEN 0 AND 1),
+    mock_test_weight NUMERIC(3,2) DEFAULT 0.30 CHECK (mock_test_weight BETWEEN 0 AND 1),
+    passing_threshold NUMERIC(5,2) DEFAULT 60.00,
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by INTEGER REFERENCES users(id),
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_by INTEGER REFERENCES users(id)
 );
+
+COMMENT ON COLUMN grade_settings.setting_name IS '設定名（成績設定の名称）';
+COMMENT ON COLUMN grade_settings.exercise_weight IS '演習比重（演習問題の重み）';
+COMMENT ON COLUMN grade_settings.quiz_weight IS 'クイズ比重（クイズの重み）';
+COMMENT ON COLUMN grade_settings.mock_test_weight IS '模擬試験比重（模擬試験の重み）';
+COMMENT ON COLUMN grade_settings.passing_threshold IS '合格閾値（合格に必要な得点）';
+COMMENT ON COLUMN grade_settings.is_active IS '有効状態（設定の使用可否）';
+COMMENT ON COLUMN grade_settings.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN grade_settings.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN grade_settings.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN grade_settings.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Performance Indexes for optimization
 CREATE INDEX idx_exercise_questions_lecture ON exercise_question_bank(lecture_id);


### PR DESCRIPTION
## Summary
- move column comments out of definitions in V002 and V003 migrations
- ensure migrations use `COMMENT ON COLUMN` after table definitions

## Testing
- `./gradlew -Pdatabase.url=jdbc:h2:mem:testdb\;MODE=PostgreSQL -Pdatabase.username=sa -Pdatabase.password= -Dflyway.driver=org.h2.Driver flywayMigrate`


------
https://chatgpt.com/codex/tasks/task_b_68a4153410108324b0caac5c5d8fb1c6