### PR TITLE
ユーザー・会社テーブルの初期マイグレーション追加

### DIFF
--- a/src/main/resources/db/migration/V000__Create_Users_And_Companies.sql
+++ b/src/main/resources/db/migration/V000__Create_Users_And_Companies.sql
@@ -1,0 +1,85 @@
+-- V000: Create Users and Companies tables migrated from schema.sql
+
+-- ========================================
+-- companies（会社マスタ）テーブル定義
+-- ========================================
+CREATE TABLE public.companies (
+                                  id bigint NOT NULL,
+                                  name character varying(100) NOT NULL,
+                                  code character varying(20) UNIQUE,
+                                  active boolean DEFAULT true NOT NULL,
+                                  created_by bigint NOT NULL,
+                                  created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+                                  updated_by bigint NOT NULL,
+                                  updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON TABLE public.companies IS '会社マスタ';
+COMMENT ON COLUMN public.companies.id IS '会社ID';
+COMMENT ON COLUMN public.companies.name IS '会社名';
+COMMENT ON COLUMN public.companies.code IS '会社コード';
+COMMENT ON COLUMN public.companies.active IS '有効フラグ';
+COMMENT ON COLUMN public.companies.created_by IS '作成者ID';
+COMMENT ON COLUMN public.companies.created_at IS '作成日時';
+COMMENT ON COLUMN public.companies.updated_by IS '更新者ID';
+COMMENT ON COLUMN public.companies.updated_at IS '更新日時';
+
+CREATE SEQUENCE public.companies_id_seq START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;
+ALTER TABLE public.companies ALTER COLUMN id SET DEFAULT nextval('public.companies_id_seq'::regclass);
+ALTER TABLE ONLY public.companies ADD CONSTRAINT companies_pkey PRIMARY KEY (id);
+
+-- ========================================
+-- users（ユーザーマスタ）テーブル定義
+-- ========================================
+CREATE TABLE public.users (
+                              id bigint NOT NULL,
+                              username character varying(50) NOT NULL,
+                              password character varying(255) NOT NULL,
+                              email character varying(255) NOT NULL,
+                              name character varying(100) NOT NULL,
+                              company_id bigint NOT NULL,
+                              role character varying(20) NOT NULL CHECK (role IN ('ADMIN', 'INSTRUCTOR', 'TRAINEE')),
+                              gender smallint NOT NULL CHECK (gender IN (1, 2, 3)),
+                              birthday date NOT NULL DEFAULT DATE '1999-12-22',
+                              active boolean DEFAULT true NOT NULL,
+                              created_by bigint NOT NULL,
+                              created_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
+                              updated_by bigint NOT NULL,
+                              updated_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON TABLE public.users IS 'ユーザーマスタ';
+COMMENT ON COLUMN public.users.id IS 'ユーザーID';
+COMMENT ON COLUMN public.users.username IS 'ユーザー名';
+COMMENT ON COLUMN public.users.password IS 'パスワード（ハッシュ化）';
+COMMENT ON COLUMN public.users.email IS 'メールアドレス';
+COMMENT ON COLUMN public.users.name IS '氏名';
+COMMENT ON COLUMN public.users.company_id IS '会社ID';
+COMMENT ON COLUMN public.users.role IS 'ロール（ADMIN/INSTRUCTOR/TRAINEE）';
+COMMENT ON COLUMN public.users.gender IS '性別（1:男性、2:女性、3:無選択）';
+COMMENT ON COLUMN public.users.birthday IS '誕生日';
+COMMENT ON COLUMN public.users.active IS '有効フラグ';
+COMMENT ON COLUMN public.users.created_by IS '作成者ID';
+COMMENT ON COLUMN public.users.created_at IS '作成日時';
+COMMENT ON COLUMN public.users.updated_by IS '更新者ID';
+COMMENT ON COLUMN public.users.updated_at IS '更新日時';
+
+CREATE SEQUENCE public.users_id_seq START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;
+ALTER TABLE public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
+ALTER TABLE ONLY public.users ADD CONSTRAINT users_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.users ADD CONSTRAINT users_email_key UNIQUE (email);
+ALTER TABLE ONLY public.users ADD CONSTRAINT users_username_key UNIQUE (username);
+ALTER TABLE ONLY public.users ADD CONSTRAINT fk_users_company_id
+    FOREIGN KEY (company_id) REFERENCES public.companies(id) DEFERRABLE INITIALLY DEFERRED;
+
+CREATE FUNCTION public.update_updated_at_column() RETURNS trigger
+    LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER update_users_updated_at
+    BEFORE UPDATE ON public.users
+    FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();


### PR DESCRIPTION
## 概要
- `schema.sql` から `companies` と `users` の定義を `V000__Create_Users_And_Companies.sql` に移植
- `spring.flyway.baseline-on-migrate=true` を確認しベースラインを有効化

## 動作確認
- `./gradlew bootRun` 実行（V000〜V003 まで適用後、V004 でエラー）
- `psql` にて `flyway_schema_history` を確認し `V000` と `V001` の適用を確認

------
https://chatgpt.com/codex/tasks/task_b_68a42f5a06d483249f7f36541a94393c