### PR TITLE
fix: Java講義データのコードブロック内の単一引用符をエスケープ

### DIFF
--- a/src/main/resources/db/migration/V004__Insert_Java_Lecture_Data.sql
+++ b/src/main/resources/db/migration/V004__Insert_Java_Lecture_Data.sql
@@ -411,7 +411,7 @@ public class IDETest {
         test.displayAllMessages();
 
         System.out.println("\n=== IDE Features Test ===");
-        System.out.println("1. Try code completion: type 'test.' and see suggestions");
+        System.out.println("1. Try code completion: type ''test.'' and see suggestions");
         System.out.println("2. Try refactoring: right-click on method name");
         System.out.println("3. Try debugging: set breakpoint and run in debug mode");
     }


### PR DESCRIPTION
## Summary
- V004__Insert_Java_Lecture_Data.sql のコードブロック内の未エスケープ単一引用符を修正し、Flyway マイグレーションの構文エラーを解消

## Testing
- `./gradlew build --console=plain`


------
https://chatgpt.com/codex/tasks/task_b_68a6b92471d48324a4475946695c9846