### PR TITLE
Fix weeks FK constraint by assigning month IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 - Java は [Amazon Corretto](https://aws.amazon.com/corretto/) を使用
 - IDE は [Pleiades](https://pleiades.io/) を推奨
 
-## 進捗状況（2025-08-20時点）
+## 進捗状況（2025-08-21時点）
 - **全体進捗:** 56%
 - **月別ページ:** 100%
 - **週別ページ:** 100%

--- a/progress_and_planning.html
+++ b/progress_and_planning.html
@@ -249,6 +249,10 @@
 
         <div class="bg-white rounded shadow p-4 mb-4">
             <h2 class="fs-3 fw-bold text-custom-blue mb-4">重要な変更履歴</h2>
+            <div class="bg-info bg-opacity-10 border-start border-4 border-info p-3 mb-3">
+                <h3 class="fw-bold mb-2"><i class="fas fa-info-circle text-info me-2"></i>2025-08-21: データ初期化マイグレーション修正</h3>
+                <p class="text-muted small mb-0">monthsテーブルに固定IDを付与し、weeksテーブルとの参照整合性を確保。</p>
+            </div>
                         <div class="bg-primary bg-opacity-10 border-start border-4 border-primary p-3 mb-3">
                 <h3 class="fw-bold mb-2"><i class="fas fa-sync-alt text-primary me-2"></i>2025-08-20: 講義データスキーマ拡張</h3>
                 <p class="text-muted small mb-0">lecturesテーブルにday_id等を追加し、全54講義データを投入。</p>

--- a/src/main/resources/db/migration/V005__Create_Initial_Data.sql
+++ b/src/main/resources/db/migration/V005__Create_Initial_Data.sql
@@ -7,10 +7,10 @@ INSERT INTO grade_settings (setting_name, exercise_weight, quiz_weight, mock_tes
 VALUES ('Default Grade Settings', 0.40, 0.30, 0.30, 60.00, true, 1);
 
 -- Insert 3 Months
-INSERT INTO months (month_number, title, description, created_by) VALUES
-(1, '第1月', 'Web開発基礎とJavaScript入門', 1),
-(2, '第2月', 'フレームワーク開発とデータベース設計', 1),
-(3, '第3月', '実践開発とプロジェクト統合', 1);
+INSERT INTO months (id, month_number, title, description, created_by) VALUES
+(1, 1, '第1月', 'Web開発基礎とJavaScript入門', 1),
+(2, 2, '第2月', 'フレームワーク開発とデータベース設計', 1),
+(3, 3, '第3月', '実践開発とプロジェクト統合', 1);
 
 -- Insert Weeks (18 weeks total, 6 weeks per month)
 INSERT INTO weeks (month_id, week_number, week_name, description, created_by) VALUES 


### PR DESCRIPTION
## Summary
- ensure months use fixed IDs so weeks migration references exist
- log migration fix in planning page and update progress date in README

## Testing
- `curl -I http://localhost:8000/index.html` (fails: 404 File not found)
- `curl -I http://localhost:8000/progress_and_planning.html`
- `./gradlew build --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_b_68a6beec9af88324a885cd397f351303