### PR TITLE
fix: align question bank tables with question data migration

### DIFF
--- a/src/main/resources/db/migration/V003__Create_Question_And_Grade_Tables.sql
+++ b/src/main/resources/db/migration/V003__Create_Question_And_Grade_Tables.sql
@@ -6,12 +6,13 @@
 CREATE TABLE exercise_question_bank (
     id SERIAL PRIMARY KEY,
     lecture_id INTEGER NOT NULL REFERENCES lectures(id),
-    question_type VARCHAR(20) NOT NULL CHECK (question_type IN ('multiple_choice', 'essay', 'code', 'fill_blank')),
+    question_number INTEGER NOT NULL,
+    question_type VARCHAR(20) DEFAULT 'multiple_choice' NOT NULL CHECK (question_type IN ('multiple_choice', 'essay', 'code', 'fill_blank')),
     question_text TEXT NOT NULL,
     question_options JSON,
     correct_answer TEXT,
-    answer_explanation TEXT,
-    difficulty_level INTEGER DEFAULT 1 CHECK (difficulty_level BETWEEN 1 AND 5),
+    explanation TEXT,
+    difficulty_level VARCHAR(20) DEFAULT 'basic',
     points INTEGER DEFAULT 5 CHECK (points > 0),
     is_active BOOLEAN DEFAULT true,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -20,11 +21,12 @@ CREATE TABLE exercise_question_bank (
     updated_by INTEGER REFERENCES users(id)
 );
 
+COMMENT ON COLUMN exercise_question_bank.question_number IS '問題番号（講義内での順序）';
 COMMENT ON COLUMN exercise_question_bank.question_text IS '問題文（演習問題の内容）';
 COMMENT ON COLUMN exercise_question_bank.question_options IS '選択肢（多択問題の場合）';
 COMMENT ON COLUMN exercise_question_bank.correct_answer IS '正解（多択・穴埋め問題の正答）';
-COMMENT ON COLUMN exercise_question_bank.answer_explanation IS '解説（問題の解答説明）';
-COMMENT ON COLUMN exercise_question_bank.difficulty_level IS '難易度（1-5の5段階評価）';
+COMMENT ON COLUMN exercise_question_bank.explanation IS '解説（問題の解答説明）';
+COMMENT ON COLUMN exercise_question_bank.difficulty_level IS '難易度（basic/intermediate/advanced）';
 COMMENT ON COLUMN exercise_question_bank.points IS '配点（問題の得点）';
 COMMENT ON COLUMN exercise_question_bank.is_active IS '有効状態（問題の使用可否）';
 COMMENT ON COLUMN exercise_question_bank.created_at IS '作成日時（レコード作成時刻）';
@@ -36,11 +38,18 @@ COMMENT ON COLUMN exercise_question_bank.updated_by IS '更新者（レコード
 CREATE TABLE quiz_question_bank (
     id SERIAL PRIMARY KEY,
     lecture_id INTEGER NOT NULL REFERENCES lectures(id),
-    question_type VARCHAR(20) NOT NULL CHECK (question_type IN ('multiple_choice', 'true_false', 'short_answer')),
+    question_number INTEGER NOT NULL,
+    question_type VARCHAR(20) DEFAULT 'multiple_choice' NOT NULL CHECK (question_type IN ('multiple_choice', 'true_false', 'short_answer')),
     question_text TEXT NOT NULL,
-    question_options JSON,
+    option_a TEXT,
+    option_b TEXT,
+    option_c TEXT,
+    option_d TEXT,
+    option_e TEXT,
+    option_f TEXT,
     correct_answer TEXT NOT NULL,
-    answer_explanation TEXT,
+    explanation TEXT,
+    difficulty_level VARCHAR(20) DEFAULT 'basic',
     time_limit INTEGER DEFAULT 60,
     points INTEGER DEFAULT 10 CHECK (points > 0),
     is_active BOOLEAN DEFAULT true,
@@ -50,10 +59,17 @@ CREATE TABLE quiz_question_bank (
     updated_by INTEGER REFERENCES users(id)
 );
 
+COMMENT ON COLUMN quiz_question_bank.question_number IS '問題番号（講義内での順序）';
 COMMENT ON COLUMN quiz_question_bank.question_text IS '問題文（クイズ問題の内容）';
-COMMENT ON COLUMN quiz_question_bank.question_options IS '選択肢（多択問題の場合）';
+COMMENT ON COLUMN quiz_question_bank.option_a IS '選択肢A';
+COMMENT ON COLUMN quiz_question_bank.option_b IS '選択肢B';
+COMMENT ON COLUMN quiz_question_bank.option_c IS '選択肢C';
+COMMENT ON COLUMN quiz_question_bank.option_d IS '選択肢D';
+COMMENT ON COLUMN quiz_question_bank.option_e IS '選択肢E';
+COMMENT ON COLUMN quiz_question_bank.option_f IS '選択肢F';
 COMMENT ON COLUMN quiz_question_bank.correct_answer IS '正解（クイズ問題の正答）';
-COMMENT ON COLUMN quiz_question_bank.answer_explanation IS '解説（問題の解答説明）';
+COMMENT ON COLUMN quiz_question_bank.explanation IS '解説（問題の解答説明）';
+COMMENT ON COLUMN quiz_question_bank.difficulty_level IS '難易度（basic/intermediate/advanced）';
 COMMENT ON COLUMN quiz_question_bank.time_limit IS '制限時間（秒単位）';
 COMMENT ON COLUMN quiz_question_bank.points IS '配点（問題の得点）';
 COMMENT ON COLUMN quiz_question_bank.is_active IS '有効状態（問題の使用可否）';
@@ -309,10 +325,10 @@ CREATE INDEX idx_lecture_grades_lecture ON lecture_grades(lecture_id);
 CREATE INDEX idx_student_summaries_assignment ON student_grade_summaries(training_assignment_id);
 
 -- Unique constraints for data integrity
-ALTER TABLE exercise_question_bank ADD CONSTRAINT unique_exercise_question_order 
-    UNIQUE(lecture_id, question_text);
-ALTER TABLE quiz_question_bank ADD CONSTRAINT unique_quiz_question_order 
-    UNIQUE(lecture_id, question_text);
+ALTER TABLE exercise_question_bank ADD CONSTRAINT unique_exercise_question_order
+    UNIQUE(lecture_id, question_number);
+ALTER TABLE quiz_question_bank ADD CONSTRAINT unique_quiz_question_order
+    UNIQUE(lecture_id, question_number);
 ALTER TABLE mock_test_questions ADD CONSTRAINT unique_mock_question_order 
     UNIQUE(mock_test_id, question_order);
 ALTER TABLE lecture_grades ADD CONSTRAINT unique_lecture_assignment_grade 

--- a/src/main/resources/db/migration/V005__Create_Initial_Data.sql
+++ b/src/main/resources/db/migration/V005__Create_Initial_Data.sql
@@ -123,15 +123,15 @@ INSERT INTO lectures (day_id, lecture_number, title, description, goals, content
 (54, 54, '修了テストと振り返り', '最終評価と学習振り返り', '["修了テスト","学習振り返り","今後の計画"]', '["修了テスト","振り返り","評価","今後計画","修了式"]', '["修了テスト実施","結果分析","学習成果振り返り","スキル評価","今後の学習計画","キャリア相談","修了証授与","実践演習","ネットワーキング","継続学習リソース"]', 180, 1);
 
 -- Sample Questions for first few lectures
-INSERT INTO exercise_question_bank (lecture_id, question_type, question_text, question_options, correct_answer, answer_explanation, difficulty_level, points, created_by) VALUES 
-(1, 'multiple_choice', 'HTMLの基本構造で、文書型宣言に使用するタグはどれですか？', '{"options": ["<html>", "<!DOCTYPE html>", "<head>", "<body>"]}', '<!DOCTYPE html>', 'DOCTYPE宣言は文書がHTML5であることをブラウザに伝える重要な宣言です。', 2, 5, 1),
-(1, 'multiple_choice', 'HTMLでページのタイトルを設定するタグはどれですか？', '{"options": ["<title>", "<h1>", "<header>", "<meta>"]}', '<title>', '<title>タグはhead要素内に記述し、ブラウザのタブに表示されるタイトルを設定します。', 1, 5, 1),
-(2, 'multiple_choice', 'CSSでクラスセレクタを指定する際に使用する記号はどれですか？', '{"options": ["#", ".", "@", "&"]}', '.', 'クラスセレクタは「.」（ピリオド）を使用してクラス名を指定します。', 1, 5, 1);
+INSERT INTO exercise_question_bank (lecture_id, question_number, question_type, question_text, question_options, correct_answer, explanation, difficulty_level, points, created_by) VALUES
+(1, 1, 'multiple_choice', 'HTMLの基本構造で、文書型宣言に使用するタグはどれですか？', '{"options": ["<html>", "<!DOCTYPE html>", "<head>", "<body>"]}', '<!DOCTYPE html>', 'DOCTYPE宣言は文書がHTML5であることをブラウザに伝える重要な宣言です。', 'intermediate', 5, 1),
+(1, 2, 'multiple_choice', 'HTMLでページのタイトルを設定するタグはどれですか？', '{"options": ["<title>", "<h1>", "<header>", "<meta>"]}', '<title>', '<title>タグはhead要素内に記述し、ブラウザのタブに表示されるタイトルを設定します。', 'basic', 5, 1),
+(2, 1, 'multiple_choice', 'CSSでクラスセレクタを指定する際に使用する記号はどれですか？', '{"options": ["#", ".", "@", "&"]}', '.', 'クラスセレクタは「.」（ピリオド）を使用してクラス名を指定します。', 'basic', 5, 1);
 
 -- Sample Quiz Questions
-INSERT INTO quiz_question_bank (lecture_id, question_type, question_text, question_options, correct_answer, answer_explanation, points, created_by) VALUES 
-(1, 'multiple_choice', 'HTML5のセマンティック要素として正しいものはどれですか？', '{"options": ["<div>", "<span>", "<section>", "<b>"]}', '<section>', '<section>は内容のまとまりを表すセマンティック要素です。', 10, 1),
-(2, 'true_false', 'CSSのBoxモデルでは、marginは要素の内側の余白を指す。', '{"options": ["true", "false"]}', 'false', 'marginは要素の外側の余白です。内側の余白はpaddingです。', 10, 1);
+INSERT INTO quiz_question_bank (lecture_id, question_number, question_type, question_text, option_a, option_b, option_c, option_d, option_e, option_f, correct_answer, explanation, difficulty_level, points, created_by) VALUES
+(1, 1, 'multiple_choice', 'HTML5のセマンティック要素として正しいものはどれですか？', '<div>', '<span>', '<section>', '<b>', NULL, NULL, '<section>', '<section>は内容のまとまりを表すセマンティック要素です。', 'basic', 10, 1),
+(2, 1, 'true_false', 'CSSのBoxモデルでは、marginは要素の内側の余白を指す。', 'true', 'false', NULL, NULL, NULL, NULL, 'false', 'marginは要素の外側の余白です。内側の余白はpaddingです。', 'basic', 10, 1);
 
 -- Mock Tests
 INSERT INTO mock_test_bank (test_name, description, duration_minutes, total_points, passing_score, created_by) VALUES 


### PR DESCRIPTION
## Summary
- add question_number and explanation columns to question bank tables and use text difficulty levels
- update initial seed data to new schema
- restore full question data migration
- support up to six options in quiz question bank

## Testing
- `./gradlew build --console=plain`


------
https://chatgpt.com/codex/tasks/task_b_68a6c2a829b483249e1a273446380546