### PR TITLE
V008データ対応のテーブル定義修正

### DIFF
--- a/src/main/resources/db/migration/V002__Create_Training_Management_Tables.sql
+++ b/src/main/resources/db/migration/V002__Create_Training_Management_Tables.sql
@@ -9,6 +9,9 @@ CREATE TABLE training_programs (
     description TEXT,
     company_id INTEGER REFERENCES companies(id),
     duration_months INTEGER DEFAULT 3 CHECK (duration_months > 0),
+    total_hours INTEGER DEFAULT 0,
+    difficulty_level VARCHAR(20),
+    prerequisites TEXT,
     max_students INTEGER DEFAULT 30 CHECK (max_students > 0),
     is_template BOOLEAN DEFAULT false,
     is_active BOOLEAN DEFAULT true,
@@ -22,6 +25,9 @@ COMMENT ON COLUMN training_programs.program_name IS 'プログラム名（研修
 COMMENT ON COLUMN training_programs.description IS '説明（プログラムの詳細説明）';
 COMMENT ON COLUMN training_programs.company_id IS '会社ID（プログラムを実施する会社）';
 COMMENT ON COLUMN training_programs.duration_months IS '期間月数（プログラムの実施期間）';
+COMMENT ON COLUMN training_programs.total_hours IS '総学習時間（総時間数）';
+COMMENT ON COLUMN training_programs.difficulty_level IS '難易度レベル';
+COMMENT ON COLUMN training_programs.prerequisites IS '受講前提条件（事前に必要なスキル）';
 COMMENT ON COLUMN training_programs.max_students IS '最大受講者数（プログラムの定員）';
 COMMENT ON COLUMN training_programs.is_template IS 'テンプレート（他社コピー用テンプレートか）';
 COMMENT ON COLUMN training_programs.is_active IS '有効状態（プログラムの使用可否）';
@@ -65,6 +71,8 @@ CREATE TABLE instructors (
     user_id INTEGER NOT NULL UNIQUE REFERENCES users(id),
     instructor_code VARCHAR(50) UNIQUE,
     specialties JSON,
+    specialization TEXT,
+    experience_years INTEGER,
     bio TEXT,
     certifications JSON,
     hourly_rate DECIMAL(10,2),
@@ -77,6 +85,8 @@ CREATE TABLE instructors (
 
 COMMENT ON COLUMN instructors.instructor_code IS '講師コード（講師の識別コード）';
 COMMENT ON COLUMN instructors.specialties IS '専門分野（講師の専門分野リスト）';
+COMMENT ON COLUMN instructors.specialization IS '専門分野（主な指導領域）';
+COMMENT ON COLUMN instructors.experience_years IS '経験年数（講師としての実務年数）';
 COMMENT ON COLUMN instructors.bio IS '経歴（講師の経歴・プロフィール）';
 COMMENT ON COLUMN instructors.certifications IS '資格（講師の保有資格リスト）';
 COMMENT ON COLUMN instructors.hourly_rate IS '時間単価（講師の時間あたり報酬）';
@@ -97,6 +107,9 @@ CREATE TABLE students (
     experience_years INTEGER DEFAULT 0 CHECK (experience_years >= 0),
     education_background VARCHAR(200),
     motivation TEXT,
+    enrollment_date DATE,
+    student_status VARCHAR(20),
+    learning_goals TEXT,
     is_active BOOLEAN DEFAULT true,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     created_by INTEGER REFERENCES users(id),
@@ -111,6 +124,9 @@ COMMENT ON COLUMN students.position IS '役職（受講者の役職）';
 COMMENT ON COLUMN students.experience_years IS '経験年数（プログラミング経験年数）';
 COMMENT ON COLUMN students.education_background IS '学歴（受講者の学歴）';
 COMMENT ON COLUMN students.motivation IS '受講動機（受講の動機・目標）';
+COMMENT ON COLUMN students.enrollment_date IS '登録日（受講開始日）';
+COMMENT ON COLUMN students.student_status IS '受講状態（active等）';
+COMMENT ON COLUMN students.learning_goals IS '学習目標（受講者の目標）';
 COMMENT ON COLUMN students.is_active IS '有効状態（受講者の活動状態）';
 COMMENT ON COLUMN students.created_at IS '作成日時（レコード作成時刻）';
 COMMENT ON COLUMN students.created_by IS '作成者（レコード作成したユーザーID）';
@@ -165,7 +181,57 @@ COMMENT ON COLUMN schedule_instructors.end_date IS '終了日（担当終了日�
 COMMENT ON COLUMN schedule_instructors.created_at IS '作成日時（レコード作成時刻）';
 COMMENT ON COLUMN schedule_instructors.created_by IS '作成者（レコード作成したユーザーID）';
 
+-- Program Schedules (overall schedule per training program)
+CREATE TABLE program_schedules (
+    id SERIAL PRIMARY KEY,
+    program_id INTEGER NOT NULL REFERENCES training_programs(id),
+    instructor_id INTEGER REFERENCES instructors(id),
+    start_date DATE NOT NULL,
+    end_date DATE NOT NULL,
+    max_students INTEGER DEFAULT 0,
+    current_students INTEGER DEFAULT 0,
+    schedule_status VARCHAR(20) DEFAULT 'scheduled',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON COLUMN program_schedules.program_id IS '研修プログラムID（training_programs.id）';
+COMMENT ON COLUMN program_schedules.instructor_id IS '講師ID（instructors.id）';
+COMMENT ON COLUMN program_schedules.start_date IS '開始日';
+COMMENT ON COLUMN program_schedules.end_date IS '終了日';
+COMMENT ON COLUMN program_schedules.max_students IS '最大受講者数';
+COMMENT ON COLUMN program_schedules.current_students IS '現在の受講者数';
+COMMENT ON COLUMN program_schedules.schedule_status IS 'スケジュール状態';
+
+-- Daily Schedules (daily breakdown for a program schedule)
+CREATE TABLE daily_schedules (
+    id SERIAL PRIMARY KEY,
+    program_schedule_id INTEGER NOT NULL REFERENCES program_schedules(id),
+    day_id INTEGER NOT NULL REFERENCES days(id),
+    scheduled_date DATE NOT NULL,
+    start_time TIME NOT NULL,
+    end_time TIME NOT NULL,
+    classroom VARCHAR(50),
+    schedule_status VARCHAR(20) DEFAULT 'scheduled',
+    notes TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON COLUMN daily_schedules.program_schedule_id IS 'プログラムスケジュールID（program_schedules.id）';
+COMMENT ON COLUMN daily_schedules.day_id IS '日ID（days.id）';
+COMMENT ON COLUMN daily_schedules.scheduled_date IS '実施日';
+COMMENT ON COLUMN daily_schedules.start_time IS '開始時間';
+COMMENT ON COLUMN daily_schedules.end_time IS '終了時間';
+COMMENT ON COLUMN daily_schedules.classroom IS '教室';
+COMMENT ON COLUMN daily_schedules.schedule_status IS 'スケジュール状態';
+COMMENT ON COLUMN daily_schedules.notes IS '備考';
+
 -- Performance indexes for optimization
+CREATE INDEX idx_program_schedules_program ON program_schedules(program_id);
+CREATE INDEX idx_program_schedules_instructor ON program_schedules(instructor_id);
+CREATE INDEX idx_daily_schedules_program ON daily_schedules(program_schedule_id);
+CREATE INDEX idx_daily_schedules_day ON daily_schedules(day_id);
 CREATE INDEX idx_training_programs_company ON training_programs(company_id);
 CREATE INDEX idx_training_programs_active ON training_programs(is_active);
 CREATE INDEX idx_training_schedules_program ON training_schedules(training_program_id);
@@ -185,15 +251,17 @@ CREATE INDEX idx_schedule_instructors_instructor ON schedule_instructors(instruc
 -- Unique constraints for data integrity  
 ALTER TABLE training_assignments ADD CONSTRAINT unique_student_schedule 
     UNIQUE(training_schedule_id, student_id);
-ALTER TABLE schedule_instructors ADD CONSTRAINT unique_schedule_instructor_role 
+ALTER TABLE schedule_instructors ADD CONSTRAINT unique_schedule_instructor_role
     UNIQUE(training_schedule_id, instructor_id, role);
 
 -- Check constraints for data validation
-ALTER TABLE training_schedules ADD CONSTRAINT check_schedule_dates 
+ALTER TABLE program_schedules ADD CONSTRAINT check_program_schedule_dates
     CHECK (end_date >= start_date);
-ALTER TABLE training_assignments ADD CONSTRAINT check_completion_date 
+ALTER TABLE training_schedules ADD CONSTRAINT check_schedule_dates
+    CHECK (end_date >= start_date);
+ALTER TABLE training_assignments ADD CONSTRAINT check_completion_date
     CHECK (completion_date IS NULL OR completion_date >= assignment_date);
-ALTER TABLE schedule_instructors ADD CONSTRAINT check_instructor_dates 
+ALTER TABLE schedule_instructors ADD CONSTRAINT check_instructor_dates
     CHECK (end_date IS NULL OR end_date >= start_date);
 
 -- Comments on tables
@@ -203,3 +271,5 @@ COMMENT ON TABLE instructors IS '講師（講師の詳細情報を管理）';
 COMMENT ON TABLE students IS '受講者（受講者の詳細情報を管理）';
 COMMENT ON TABLE training_assignments IS '研修配属（受講者の研修配属を管理）';
 COMMENT ON TABLE schedule_instructors IS 'スケジュール講師（スケジュールと講師の関係を管理）';
+COMMENT ON TABLE program_schedules IS 'プログラムスケジュール（研修プログラムの日程を管理）';
+COMMENT ON TABLE daily_schedules IS '日次スケジュール（各プログラムスケジュールの1日単位の予定を管理）';

--- a/src/main/resources/db/migration/V003__Create_Question_And_Grade_Tables.sql
+++ b/src/main/resources/db/migration/V003__Create_Question_And_Grade_Tables.sql
@@ -251,37 +251,26 @@ COMMENT ON COLUMN lecture_grades.updated_at IS '更新日時（レコード更�
 -- Student Grade Summaries (overall progress tracking)
 CREATE TABLE student_grade_summaries (
     id SERIAL PRIMARY KEY,
-    training_assignment_id INTEGER NOT NULL REFERENCES training_assignments(id),
-    total_exercise_score INTEGER DEFAULT 0,
-    total_exercise_max_score INTEGER DEFAULT 0,
-    total_quiz_score INTEGER DEFAULT 0,
-    total_quiz_max_score INTEGER DEFAULT 0,
-    mock_test_best_score INTEGER DEFAULT 0,
-    mock_test_max_score INTEGER DEFAULT 100,
-    final_grade NUMERIC(5,2),
-    grade_letter VARCHAR(2),
-    lectures_completed INTEGER DEFAULT 0,
-    total_lectures INTEGER DEFAULT 54,
-    attendance_rate NUMERIC(5,2),
-    progress_percentage NUMERIC(5,2),
-    last_activity_date TIMESTAMP,
+    student_id INTEGER NOT NULL REFERENCES students(id),
+    lecture_id INTEGER NOT NULL REFERENCES lectures(id),
+    exercise_score NUMERIC(5,2) DEFAULT 0,
+    quiz_score NUMERIC(5,2) DEFAULT 0,
+    mock_test_score NUMERIC(5,2) DEFAULT 0,
+    total_score NUMERIC(5,2) DEFAULT 0,
+    grade_status VARCHAR(20),
+    calculated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
-COMMENT ON COLUMN student_grade_summaries.total_exercise_score IS '演習総得点（全演習問題の合計得点）';
-COMMENT ON COLUMN student_grade_summaries.total_exercise_max_score IS '演習総満点（全演習問題の満点）';
-COMMENT ON COLUMN student_grade_summaries.total_quiz_score IS 'クイズ総得点（全クイズの合計得点）';
-COMMENT ON COLUMN student_grade_summaries.total_quiz_max_score IS 'クイズ総満点（全クイズの満点）';
-COMMENT ON COLUMN student_grade_summaries.mock_test_best_score IS '模擬試験最高得点（模擬試験の最高得点）';
-COMMENT ON COLUMN student_grade_summaries.mock_test_max_score IS '模擬試験満点（模擬試験の満点）';
-COMMENT ON COLUMN student_grade_summaries.final_grade IS '最終成績（40%演習+30%クイズ+30%模擬試験）';
-COMMENT ON COLUMN student_grade_summaries.grade_letter IS '成績評価（A、B、C、D、Fの評価）';
-COMMENT ON COLUMN student_grade_summaries.lectures_completed IS '完了講義数（完了した講義の数）';
-COMMENT ON COLUMN student_grade_summaries.total_lectures IS '総講義数（全講義の数）';
-COMMENT ON COLUMN student_grade_summaries.attendance_rate IS '出席率（出席講義数/総講義数）';
-COMMENT ON COLUMN student_grade_summaries.progress_percentage IS '進捗率（完了度のパーセンテージ）';
-COMMENT ON COLUMN student_grade_summaries.last_activity_date IS '最終活動日（最後の学習活動日時）';
+COMMENT ON COLUMN student_grade_summaries.student_id IS '学生ID（students.id）';
+COMMENT ON COLUMN student_grade_summaries.lecture_id IS '講義ID（lectures.id）';
+COMMENT ON COLUMN student_grade_summaries.exercise_score IS '演習得点';
+COMMENT ON COLUMN student_grade_summaries.quiz_score IS 'クイズ得点';
+COMMENT ON COLUMN student_grade_summaries.mock_test_score IS '模擬試験得点';
+COMMENT ON COLUMN student_grade_summaries.total_score IS '総合得点';
+COMMENT ON COLUMN student_grade_summaries.grade_status IS '成績評価ステータス';
+COMMENT ON COLUMN student_grade_summaries.calculated_at IS '集計日時';
 COMMENT ON COLUMN student_grade_summaries.created_at IS '作成日時（レコード作成時刻）';
 COMMENT ON COLUMN student_grade_summaries.updated_at IS '更新日時（レコード更新時刻）';
 
@@ -324,7 +313,8 @@ CREATE INDEX idx_quiz_submissions_lecture ON quiz_submissions(lecture_id);
 CREATE INDEX idx_mock_submissions_assignment ON mock_test_submissions(training_assignment_id);
 CREATE INDEX idx_lecture_grades_assignment ON lecture_grades(training_assignment_id);
 CREATE INDEX idx_lecture_grades_lecture ON lecture_grades(lecture_id);
-CREATE INDEX idx_student_summaries_assignment ON student_grade_summaries(training_assignment_id);
+CREATE INDEX idx_student_summaries_student ON student_grade_summaries(student_id);
+CREATE INDEX idx_student_summaries_lecture ON student_grade_summaries(lecture_id);
 
 -- Unique constraints for data integrity
 ALTER TABLE exercise_question_bank ADD CONSTRAINT unique_exercise_question_order
@@ -333,10 +323,10 @@ ALTER TABLE quiz_question_bank ADD CONSTRAINT unique_quiz_question_order
     UNIQUE(lecture_id, question_number);
 ALTER TABLE mock_test_questions ADD CONSTRAINT unique_mock_question_order 
     UNIQUE(mock_test_id, question_order);
-ALTER TABLE lecture_grades ADD CONSTRAINT unique_lecture_assignment_grade 
+ALTER TABLE lecture_grades ADD CONSTRAINT unique_lecture_assignment_grade
     UNIQUE(training_assignment_id, lecture_id);
-ALTER TABLE student_grade_summaries ADD CONSTRAINT unique_student_summary 
-    UNIQUE(training_assignment_id);
+ALTER TABLE student_grade_summaries ADD CONSTRAINT unique_student_summary
+    UNIQUE(student_id, lecture_id);
 
 -- Add constraint to ensure grade weights sum to 1.0
 ALTER TABLE grade_settings ADD CONSTRAINT check_weights_sum 
@@ -352,5 +342,5 @@ COMMENT ON TABLE quiz_submissions IS 'クイズ提出（学生のクイズ解答
 COMMENT ON TABLE mock_test_submissions IS '模擬試験提出（学生の模擬試験受験を管理）';
 COMMENT ON TABLE mock_test_answers IS '模擬試験解答（模擬試験の個別問題解答を管理）';
 COMMENT ON TABLE lecture_grades IS '講義成績（各講義の成績を管理）';
-COMMENT ON TABLE student_grade_summaries IS '学生成績概要（学生の全体成績を管理）';
+COMMENT ON TABLE student_grade_summaries IS '学生成績集計（学生と講義ごとの成績を管理）';
 COMMENT ON TABLE grade_settings IS '成績設定（成績計算の重み設定を管理）';


### PR DESCRIPTION
## 概要
- 研修プログラム・講師・学生テーブルにV008のデータで必要な列を追加
- プログラムスケジュール／日次スケジュールと成績集計テーブルを新規定義

## テスト
- `./gradlew build`
- `npm run test:e2e` (psql が見つからず失敗)

------
https://chatgpt.com/codex/tasks/task_b_68a70f6af3488324b00a950aec6a9f27