### PR TITLE
fix: add daily schedule fields

### DIFF
--- a/src/main/resources/db/migration/V000__Create_Users_And_Companies.sql
+++ b/src/main/resources/db/migration/V000__Create_Users_And_Companies.sql
@@ -644,9 +644,11 @@ CREATE TABLE daily_schedules (
     scheduled_date DATE NOT NULL,
     start_time TIME NOT NULL,
     end_time TIME NOT NULL,
-    classroom VARCHAR(50),
-    schedule_status VARCHAR(20) DEFAULT 'scheduled',
+    venue VARCHAR(100),
+    daily_theme VARCHAR(200),
+    daily_objectives VARCHAR(500),
     notes TEXT,
+    daily_status VARCHAR(20) DEFAULT 'SCHEDULED',
     version BIGINT NOT NULL DEFAULT 0,
     created_by BIGINT REFERENCES users(id),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
@@ -659,9 +661,11 @@ COMMENT ON COLUMN daily_schedules.day_id IS '日ID（days.id）';
 COMMENT ON COLUMN daily_schedules.scheduled_date IS '実施日';
 COMMENT ON COLUMN daily_schedules.start_time IS '開始時間';
 COMMENT ON COLUMN daily_schedules.end_time IS '終了時間';
-COMMENT ON COLUMN daily_schedules.classroom IS '教室';
-COMMENT ON COLUMN daily_schedules.schedule_status IS 'スケジュール状態';
+COMMENT ON COLUMN daily_schedules.venue IS '会場';
+COMMENT ON COLUMN daily_schedules.daily_theme IS '日次テーマ';
+COMMENT ON COLUMN daily_schedules.daily_objectives IS '日次目標';
 COMMENT ON COLUMN daily_schedules.notes IS '備考';
+COMMENT ON COLUMN daily_schedules.daily_status IS '日次ステータス';
 COMMENT ON COLUMN daily_schedules.version IS 'バージョン（楽観ロック用）';
 COMMENT ON COLUMN daily_schedules.created_by IS '作成者（レコード作成したユーザーID）';
 COMMENT ON COLUMN daily_schedules.created_at IS '作成日時（レコード作成時刻）';

--- a/src/main/resources/db/migration/V008__Insert_Basic_Data.sql
+++ b/src/main/resources/db/migration/V008__Insert_Basic_Data.sql
@@ -38,22 +38,26 @@ INSERT INTO program_schedules (id, program_id, instructor_id, start_date, end_da
 -- DAILY SCHEDULES DATA (日次スケジュールデータ)
 -- ===============================
 
-INSERT INTO daily_schedules (id, program_schedule_id, day_id, scheduled_date, start_time, end_time, classroom, schedule_status, notes, created_by, created_at, updated_by, updated_at) VALUES
-(1, 1, 1, '2024-01-15', '09:00:00', '12:00:00', 'A101', 'completed', '初回オリエンテーション実施', 1, NOW(), 1, NOW()),
-(2, 1, 2, '2024-01-16', '09:00:00', '12:00:00', 'A101', 'completed', NULL, 1, NOW(), 1, NOW()),
-(3, 1, 3, '2024-01-17', '09:00:00', '12:00:00', 'A101', 'completed', NULL, 1, NOW(), 1, NOW()),
-(4, 1, 4, '2024-01-18', '09:00:00', '12:00:00', 'A101', 'completed', NULL, 1, NOW(), 1, NOW()),
-(5, 1, 5, '2024-01-19', '09:00:00', '12:00:00', 'A101', 'completed', '週末課題説明', 1, NOW(), 1, NOW()),
-(6, 1, 6, '2024-01-22', '09:00:00', '12:00:00', 'A101', 'scheduled', NULL, 1, NOW(), 1, NOW()),
-(7, 1, 7, '2024-01-23', '09:00:00', '12:00:00', 'A101', 'scheduled', NULL, 1, NOW(), 1, NOW()),
-(8, 1, 8, '2024-01-24', '09:00:00', '12:00:00', 'A101', 'scheduled', NULL, 1, NOW(), 1, NOW()),
-(9, 1, 9, '2024-01-25', '09:00:00', '12:00:00', 'A101', 'scheduled', NULL, 1, NOW(), 1, NOW()),
-(10, 1, 10, '2024-01-26', '09:00:00', '12:00:00', 'A101', 'scheduled', NULL, 1, NOW(), 1, NOW()),
-(11, 2, 17, '2024-02-01', '13:00:00', '17:00:00', 'B201', 'scheduled', 'Web開発コース開始', 1, NOW(), 1, NOW()),
-(12, 2, 18, '2024-02-02', '13:00:00', '17:00:00', 'B201', 'scheduled', NULL, 1, NOW(), 1, NOW()),
-(13, 2, 19, '2024-02-05', '13:00:00', '17:00:00', 'B201', 'scheduled', NULL, 1, NOW(), 1, NOW()),
-(14, 2, 20, '2024-02-06', '13:00:00', '17:00:00', 'B201', 'scheduled', NULL, 1, NOW(), 1, NOW()),
-(15, 2, 21, '2024-02-07', '13:00:00', '17:00:00', 'B201', 'scheduled', NULL, 1, NOW(), 1, NOW());
+INSERT INTO daily_schedules (
+    id, program_schedule_id, day_id, scheduled_date, start_time, end_time,
+    venue, daily_theme, daily_objectives, notes, daily_status,
+    created_by, created_at, updated_by, updated_at
+) VALUES
+(1, 1, 1, '2024-01-15', '09:00:00', '12:00:00', 'A101', NULL, NULL, '初回オリエンテーション実施', 'COMPLETED', 1, NOW(), 1, NOW()),
+(2, 1, 2, '2024-01-16', '09:00:00', '12:00:00', 'A101', NULL, NULL, NULL, 'COMPLETED', 1, NOW(), 1, NOW()),
+(3, 1, 3, '2024-01-17', '09:00:00', '12:00:00', 'A101', NULL, NULL, NULL, 'COMPLETED', 1, NOW(), 1, NOW()),
+(4, 1, 4, '2024-01-18', '09:00:00', '12:00:00', 'A101', NULL, NULL, NULL, 'COMPLETED', 1, NOW(), 1, NOW()),
+(5, 1, 5, '2024-01-19', '09:00:00', '12:00:00', 'A101', NULL, NULL, '週末課題説明', 'COMPLETED', 1, NOW(), 1, NOW()),
+(6, 1, 6, '2024-01-22', '09:00:00', '12:00:00', 'A101', NULL, NULL, NULL, 'SCHEDULED', 1, NOW(), 1, NOW()),
+(7, 1, 7, '2024-01-23', '09:00:00', '12:00:00', 'A101', NULL, NULL, NULL, 'SCHEDULED', 1, NOW(), 1, NOW()),
+(8, 1, 8, '2024-01-24', '09:00:00', '12:00:00', 'A101', NULL, NULL, NULL, 'SCHEDULED', 1, NOW(), 1, NOW()),
+(9, 1, 9, '2024-01-25', '09:00:00', '12:00:00', 'A101', NULL, NULL, NULL, 'SCHEDULED', 1, NOW(), 1, NOW()),
+(10, 1, 10, '2024-01-26', '09:00:00', '12:00:00', 'A101', NULL, NULL, NULL, 'SCHEDULED', 1, NOW(), 1, NOW()),
+(11, 2, 17, '2024-02-01', '13:00:00', '17:00:00', 'B201', NULL, NULL, 'Web開発コース開始', 'SCHEDULED', 1, NOW(), 1, NOW()),
+(12, 2, 18, '2024-02-02', '13:00:00', '17:00:00', 'B201', NULL, NULL, NULL, 'SCHEDULED', 1, NOW(), 1, NOW()),
+(13, 2, 19, '2024-02-05', '13:00:00', '17:00:00', 'B201', NULL, NULL, NULL, 'SCHEDULED', 1, NOW(), 1, NOW()),
+(14, 2, 20, '2024-02-06', '13:00:00', '17:00:00', 'B201', NULL, NULL, NULL, 'SCHEDULED', 1, NOW(), 1, NOW()),
+(15, 2, 21, '2024-02-07', '13:00:00', '17:00:00', 'B201', NULL, NULL, NULL, 'SCHEDULED', 1, NOW(), 1, NOW());
 
 -- ===============================
 -- STUDENT GRADE SUMMARIES DATA (学生成績集計データ)

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -643,9 +643,11 @@ CREATE TABLE daily_schedules (
     scheduled_date DATE NOT NULL,
     start_time TIME NOT NULL,
     end_time TIME NOT NULL,
-    classroom VARCHAR(50),
-    schedule_status VARCHAR(20) DEFAULT 'scheduled',
+    venue VARCHAR(100),
+    daily_theme VARCHAR(200),
+    daily_objectives VARCHAR(500),
     notes TEXT,
+    daily_status VARCHAR(20) DEFAULT 'SCHEDULED',
     created_by BIGINT REFERENCES users(id),
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_by BIGINT REFERENCES users(id),
@@ -657,9 +659,11 @@ COMMENT ON COLUMN daily_schedules.day_id IS '日ID（days.id）';
 COMMENT ON COLUMN daily_schedules.scheduled_date IS '実施日';
 COMMENT ON COLUMN daily_schedules.start_time IS '開始時間';
 COMMENT ON COLUMN daily_schedules.end_time IS '終了時間';
-COMMENT ON COLUMN daily_schedules.classroom IS '教室';
-COMMENT ON COLUMN daily_schedules.schedule_status IS 'スケジュール状態';
+COMMENT ON COLUMN daily_schedules.venue IS '会場';
+COMMENT ON COLUMN daily_schedules.daily_theme IS '日次テーマ';
+COMMENT ON COLUMN daily_schedules.daily_objectives IS '日次目標';
 COMMENT ON COLUMN daily_schedules.notes IS '備考';
+COMMENT ON COLUMN daily_schedules.daily_status IS '日次ステータス';
 COMMENT ON COLUMN daily_schedules.created_by IS '作成者（レコード作成したユーザーID）';
 COMMENT ON COLUMN daily_schedules.created_at IS '作成日時（レコード作成時刻）';
 COMMENT ON COLUMN daily_schedules.updated_by IS '更新者（レコード更新したユーザーID）';


### PR DESCRIPTION
## Summary
- add venue, daily_theme, daily_objectives, daily_status columns to daily_schedules table
- align initial data with new daily schedule schema

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_b_68a822d0068c8324b7a19f7c44400a58