### PR TITLE
Add is_active column to instructors table

### DIFF
--- a/src/main/resources/db/migration/V000__Create_Users_And_Companies.sql
+++ b/src/main/resources/db/migration/V000__Create_Users_And_Companies.sql
@@ -447,6 +447,7 @@ CREATE TABLE instructors (
     bio VARCHAR(1000),
     instructor_status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
     availability VARCHAR(500),
+    is_active BOOLEAN DEFAULT true,
     profile_updated_at TIMESTAMP WITH TIME ZONE,
     version BIGINT NOT NULL DEFAULT 0,
     created_by BIGINT REFERENCES users(id),
@@ -469,6 +470,7 @@ COMMENT ON COLUMN instructors.last_teaching_date IS '最終指導日時';
 COMMENT ON COLUMN instructors.bio IS '自己紹介';
 COMMENT ON COLUMN instructors.instructor_status IS '講師ステータス';
 COMMENT ON COLUMN instructors.availability IS '可用性情報';
+COMMENT ON COLUMN instructors.is_active IS '有効状態（講師の活動状態）';
 COMMENT ON COLUMN instructors.profile_updated_at IS 'プロファイル更新日時';
 COMMENT ON COLUMN instructors.version IS 'バージョン（楽観ロック用）';
 COMMENT ON COLUMN instructors.created_at IS '作成日時（レコード作成時刻）';

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -448,6 +448,7 @@ CREATE TABLE instructors (
     bio VARCHAR(1000),
     instructor_status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
     availability VARCHAR(500),
+    is_active BOOLEAN DEFAULT true,
     profile_updated_at TIMESTAMP WITH TIME ZONE,
     version BIGINT NOT NULL DEFAULT 0,
     created_by BIGINT REFERENCES users(id),
@@ -470,6 +471,7 @@ COMMENT ON COLUMN instructors.last_teaching_date IS '最終指導日時';
 COMMENT ON COLUMN instructors.bio IS '自己紹介';
 COMMENT ON COLUMN instructors.instructor_status IS '講師ステータス';
 COMMENT ON COLUMN instructors.availability IS '可用性情報';
+COMMENT ON COLUMN instructors.is_active IS '有効状態（講師の活動状態）';
 COMMENT ON COLUMN instructors.profile_updated_at IS 'プロファイル更新日時';
 COMMENT ON COLUMN instructors.version IS 'バージョン（楽観ロック用）';
 COMMENT ON COLUMN instructors.created_at IS '作成日時（レコード作成時刻）';
@@ -769,6 +771,7 @@ CREATE INDEX idx_training_schedules_instructor ON training_schedules(instructor_
 CREATE INDEX idx_training_schedules_dates ON training_schedules(start_date, end_date);
 CREATE INDEX idx_instructors_user ON instructors(user_id);
 CREATE INDEX idx_instructors_status ON instructors(instructor_status);
+CREATE INDEX idx_instructors_active ON instructors(is_active);
 CREATE INDEX idx_students_user ON students(user_id);
 CREATE INDEX idx_students_company ON students(company_id);
 CREATE INDEX idx_students_active ON students(is_active);


### PR DESCRIPTION
## Summary
- add missing `is_active` flag to `instructors` table migration
- document active status column
- include flag and index in `schema.sql`

## Testing
- `./gradlew build -x test`


------
https://chatgpt.com/codex/tasks/task_b_68aa985c315c83249a70bf9d49f20e00