### PR TITLE
Remove nonexistent experience_years column from instructors seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@
 - バックエンド：統合済みのV001～V003マイグレーションファイルを削除し、V008のDDLを移行
 - バックエンド：mock_testsテーブルを新設しエンティティをスキーマに対応
 - バックエンド：instructorsテーブルを再構成し、student_enrollments・quizテーブルを追加
+- バックエンド：instructors初期データから存在しないexperience_yearsカラムを削除
 
 ## 今後のタスク（優先順位順）
 1. `day6.html`〜`day54.html` の作成（残り49日分）

--- a/progress_and_planning.html
+++ b/progress_and_planning.html
@@ -204,6 +204,11 @@
                             <span class="badge bg-success small me-2">2025-08-24</span>
                             バックエンド：user_rolesテーブルのDDLをV000とschema.sqlに統合
                         </li>
+                        <li class="mb-2">
+                            <i class="fas fa-check-circle text-success me-2"></i>
+                            <span class="badge bg-success small me-2">2025-08-24</span>
+                            バックエンド：instructors初期データから存在しないexperience_yearsカラムを削除
+                        </li>
                     </ul>
                 </div>
                 <div class="col-md-6">
@@ -254,6 +259,10 @@
 
         <div class="bg-white rounded shadow p-4 mb-4">
 <h2 class="fs-3 fw-bold text-custom-blue mb-4">重要な変更履歴</h2>
+            <div class="bg-secondary bg-opacity-10 border-start border-4 border-secondary p-3 mb-3">
+                <h3 class="fw-bold mb-2"><i class="fas fa-tools text-secondary me-2"></i>2025-08-24: 初期データマイグレーション修正</h3>
+                <p class="text-muted small mb-0">instructors初期データから存在しないexperience_yearsカラムを削除し、スキーマ整合性を確保。</p>
+            </div>
             <div class="bg-secondary bg-opacity-10 border-start border-4 border-secondary p-3 mb-3">
                 <h3 class="fw-bold mb-2"><i class="fas fa-tools text-secondary me-2"></i>2025-08-22: スキーマ整合性修正</h3>
                 <p class="text-muted small mb-0">instructorsに担当数カラムを追加し、student_enrollments・quizテーブルを新設。</p>

--- a/src/main/resources/db/migration/V008__Insert_Basic_Data.sql
+++ b/src/main/resources/db/migration/V008__Insert_Basic_Data.sql
@@ -6,8 +6,8 @@
 -- INSTRUCTORS DATA (講師データ)
 -- ===============================
 
-INSERT INTO instructors (id, user_id, specialization, experience_years, bio, created_by, created_at, updated_by, updated_at) VALUES
-(1, 2, 'データ構造,アルゴリズム,C++', 12, 'アルゴリズム設計の専門家として12年間の実務経験。効率的なプログラム設計と最適化技術の指導を得意とする。', 1, NOW(), 1, NOW());
+INSERT INTO instructors (id, user_id, specialization, bio, created_by, created_at, updated_by, updated_at) VALUES
+(1, 2, 'データ構造,アルゴリズム,C++', 'アルゴリズム設計の専門家として12年間の実務経験。効率的なプログラム設計と最適化技術の指導を得意とする。', 1, NOW(), 1, NOW());
 
 -- ===============================
 -- STUDENTS DATA (学生データ)


### PR DESCRIPTION
## Summary
- instructors初期データマイグレーションから存在しない`experience_years`カラムを削除
- 進捗ドキュメントとREADMEを更新

## Testing
- `curl -I http://localhost:8000/index.html`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_b_68aa9b1f9cdc832490b7504213ddb48f