### PR TITLE
fix: Lectureエンティティのday_id型不一致を解消

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/domain/entity/Lecture.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/entity/Lecture.java
@@ -21,7 +21,7 @@ public class Lecture extends AuditableEntity {
 
     /** 紐づく日ID */
     @Column(name = "day_id")
-    private Integer dayId;
+    private Long dayId;
 
     /** 講義番号 */
     @Column(name = "lecture_number")


### PR DESCRIPTION
## Summary
- lecturesテーブルのday_idカラムに対応するエンティティの型をIntegerからLongへ変更

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68aac0d3f0b88324b563c7347a47a373