### PR TITLE
Fix JPA schema mismatches and invalid repository queries

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/domain/entity/User.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/entity/User.java
@@ -65,7 +65,7 @@ public class User {
     @Min(1)
     @Max(3)
     @Column(name = "gender", nullable = false)
-    private Integer gender;
+    private Short gender;
 
     @NotNull(message = "誕生日は必須です")
     @Column(name = "birthday", nullable = false)
@@ -98,7 +98,7 @@ public class User {
 
     /** User メソッド */
     public User(String username, String password, String email, String name,
-                Long companyId, String role, Integer gender, LocalDate birthday,
+                Long companyId, String role, Short gender, LocalDate birthday,
                 Long createdBy, Long updatedBy) {
         this();
         this.username = username;
@@ -143,9 +143,9 @@ public class User {
     /** setRole メソッド */
     public void setRole(String role) { this.role = role; }
     /** getGender メソッド */
-    public Integer getGender() { return gender; }
+    public Short getGender() { return gender; }
     /** setGender メソッド */
-    public void setGender(Integer gender) { this.gender = gender; }
+    public void setGender(Short gender) { this.gender = gender; }
     /** getBirthday メソッド */
     public LocalDate getBirthday() { return birthday; }
     /** setBirthday メソッド */

--- a/src/main/java/jp/co/apsa/giiku/domain/repository/AuditLogRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/AuditLogRepository.java
@@ -115,14 +115,6 @@ public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
     Page<AuditLog> findByIpAddressOrderByCreatedAtDesc(String ipAddress, Pageable pageable);
 
     /**
-     * セッションIDで監査ログを検索
-     * 
-     * @param sessionId セッションID
-     * @return 監査ログリスト
-     */
-    List<AuditLog> findBySessionIdOrderByCreatedAtAsc(String sessionId);
-
-    /**
      * 特定期間の監査ログ件数を取得
      * 統計・レポート用
      * 

--- a/src/main/java/jp/co/apsa/giiku/domain/repository/CompanyLmsConfigRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/CompanyLmsConfigRepository.java
@@ -26,55 +26,6 @@ public interface CompanyLmsConfigRepository extends JpaRepository<CompanyLmsConf
      */
     List<CompanyLmsConfig> findByCompanyId(Long companyId);
 
-    /**
-     * アクティブなLMS設定一覧を取得
-     *
-     * @return アクティブなLMS設定一覧
-     */
-    List<CompanyLmsConfig> findByActiveTrue();
-
-    /**
-     * 指定された企業IDのアクティブなLMS設定を取得
-     *
-     * @param companyId 企業ID
-     * @return アクティブなLMS設定（存在する場合）
-     */
-    Optional<CompanyLmsConfig> findByCompanyIdAndActiveTrue(Long companyId);
-
-    /**
-     * 指定された企業IDの非アクティブなLMS設定一覧を取得
-     *
-     * @param companyId 企業ID
-     * @return 非アクティブなLMS設定一覧
-     */
-    List<CompanyLmsConfig> findByCompanyIdAndActiveFalse(Long companyId);
-
-    /**
-     * 指定された設定名と企業IDでLMS設定を検索
-     *
-     * @param configName 設定名
-     * @param companyId 企業ID
-     * @return 該当するLMS設定（存在する場合）
-     */
-    Optional<CompanyLmsConfig> findByConfigNameAndCompanyId(String configName, Long companyId);
-
-    /**
-     * 指定された設定タイプの設定一覧を取得
-     *
-     * @param configType 設定タイプ
-     * @return 該当する設定一覧
-     */
-    List<CompanyLmsConfig> findByConfigType(String configType);
-
-    /**
-     * 指定された企業IDと設定タイプの設定一覧を取得
-     *
-     * @param companyId 企業ID
-     * @param configType 設定タイプ
-     * @return 該当する設定一覧
-     */
-    List<CompanyLmsConfig> findByCompanyIdAndConfigType(Long companyId, String configType);
-
     // JpaRepositoryから継承される基本メソッド:
     // - findAll()
     // - findById(Long id)

--- a/src/main/java/jp/co/apsa/giiku/domain/repository/QuizRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/QuizRepository.java
@@ -27,46 +27,46 @@ public interface QuizRepository extends JpaRepository<Quiz, Long>, JpaSpecificat
     List<Quiz> findByStudentIdOrderByStartTimeDesc(Long studentId);
 
     /**
-     * プログラムIDでクイズを取得
+     * トレーニングプログラムIDでクイズを取得
      *
-     * @param programId プログラムID
+     * @param trainingProgramId トレーニングプログラムID
      * @return クイズリスト
      */
-    List<Quiz> findByProgramIdOrderByStartTimeDesc(Long programId);
+    List<Quiz> findByTrainingProgramIdOrderByStartTimeDesc(Long trainingProgramId);
 
     /**
-     * ステータスでクイズを取得（開始時刻順）
+     * クイズステータスでクイズを取得（開始時刻順）
      *
-     * @param status クイズステータス
+     * @param quizStatus クイズステータス
      * @return クイズリスト
      */
-    List<Quiz> findByStatusOrderByStartTimeDesc(String status);
+    List<Quiz> findByQuizStatusOrderByStartTimeDesc(String quizStatus);
 
     /**
-     * ステータスでクイズを取得（終了時刻順）
+     * クイズステータスでクイズを取得（終了時刻順）
      *
-     * @param status クイズステータス
+     * @param quizStatus クイズステータス
      * @return クイズリスト
      */
-    List<Quiz> findByStatusOrderByEndTimeDesc(String status);
+    List<Quiz> findByQuizStatusOrderByEndTimeDesc(String quizStatus);
 
     /**
-     * 学生IDとステータスでクイズを取得（開始時刻順）
+     * 学生IDとクイズステータスでクイズを取得（開始時刻順）
      *
      * @param studentId 学生ID
-     * @param status クイズステータス
+     * @param quizStatus クイズステータス
      * @return クイズリスト
      */
-    List<Quiz> findByStudentIdAndStatusOrderByStartTimeDesc(Long studentId, String status);
+    List<Quiz> findByStudentIdAndQuizStatusOrderByStartTimeDesc(Long studentId, String quizStatus);
 
     /**
-     * 学生IDとステータスでクイズを取得（終了時刻順）
+     * 学生IDとクイズステータスでクイズを取得（終了時刻順）
      *
      * @param studentId 学生ID
-     * @param status クイズステータス
+     * @param quizStatus クイズステータス
      * @return クイズリスト
      */
-    List<Quiz> findByStudentIdAndStatusOrderByEndTimeDesc(Long studentId, String status);
+    List<Quiz> findByStudentIdAndQuizStatusOrderByEndTimeDesc(Long studentId, String quizStatus);
 
     /**
      * プログラム別平均スコアを取得
@@ -93,7 +93,7 @@ public interface QuizRepository extends JpaRepository<Quiz, Long>, JpaSpecificat
      * @param status クイズステータス
      * @return 件数
      */
-    long countByStatus(String status);
+    long countByQuizStatus(String quizStatus);
 
     /**
      * 学生別件数を取得

--- a/src/main/java/jp/co/apsa/giiku/service/QuizService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/QuizService.java
@@ -132,7 +132,7 @@ public class QuizService {
         if (programId == null) {
             throw new IllegalArgumentException("プログラムIDは必須です");
         }
-        return quizRepository.findByProgramIdOrderByStartTimeDesc(programId);
+        return quizRepository.findByTrainingProgramIdOrderByStartTimeDesc(programId);
     }
 
     /** ステータスでクイズを検索 */
@@ -141,19 +141,19 @@ public class QuizService {
         if (!StringUtils.hasText(status)) {
             throw new IllegalArgumentException("ステータスは必須です");
         }
-        return quizRepository.findByStatusOrderByStartTimeDesc(status);
+        return quizRepository.findByQuizStatusOrderByStartTimeDesc(status);
     }
 
     /** 進行中のクイズを取得 */
     @Transactional(readOnly = true)
     public List<Quiz> findInProgressQuizzes() {
-        return quizRepository.findByStatusOrderByStartTimeDesc("IN_PROGRESS");
+        return quizRepository.findByQuizStatusOrderByStartTimeDesc("IN_PROGRESS");
     }
 
     /** 完了したクイズを取得 */
     @Transactional(readOnly = true)
     public List<Quiz> findCompletedQuizzes() {
-        return quizRepository.findByStatusOrderByEndTimeDesc("COMPLETED");
+        return quizRepository.findByQuizStatusOrderByEndTimeDesc("COMPLETED");
     }
 
     /** 学生の進行中クイズを取得 */
@@ -162,7 +162,7 @@ public class QuizService {
         if (studentId == null) {
             throw new IllegalArgumentException("学生IDは必須です");
         }
-        return quizRepository.findByStudentIdAndStatusOrderByStartTimeDesc(studentId, "IN_PROGRESS");
+        return quizRepository.findByStudentIdAndQuizStatusOrderByStartTimeDesc(studentId, "IN_PROGRESS");
     }
 
     /** 学生の完了クイズを取得 */
@@ -171,7 +171,7 @@ public class QuizService {
         if (studentId == null) {
             throw new IllegalArgumentException("学生IDは必須です");
         }
-        return quizRepository.findByStudentIdAndStatusOrderByEndTimeDesc(studentId, "COMPLETED");
+        return quizRepository.findByStudentIdAndQuizStatusOrderByEndTimeDesc(studentId, "COMPLETED");
     }
 
     /** プログラムの平均スコアを取得 */
@@ -207,11 +207,11 @@ public class QuizService {
             }
 
             if (programId != null) {
-                predicates.add(criteriaBuilder.equal(root.get("programId"), programId));
+                predicates.add(criteriaBuilder.equal(root.get("trainingProgramId"), programId));
             }
 
             if (StringUtils.hasText(status)) {
-                predicates.add(criteriaBuilder.equal(root.get("status"), status));
+                predicates.add(criteriaBuilder.equal(root.get("quizStatus"), status));
             }
 
             if (startTimeFrom != null) {
@@ -348,7 +348,7 @@ public class QuizService {
         if (!StringUtils.hasText(status)) {
             throw new IllegalArgumentException("ステータスは必須です");
         }
-        return quizRepository.countByStatus(status);
+        return quizRepository.countByQuizStatus(status);
     }
 
     /** 学生別のクイズ数をカウント */
@@ -369,7 +369,7 @@ public class QuizService {
 
     @Transactional(readOnly = true)
     public List<Quiz> findByQuizStatus(String status) {
-        return findByStatus(status);
+        return quizRepository.findByQuizStatusOrderByStartTimeDesc(status);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Summary
- Align `User` entity gender type with database
- Remove invalid LMS config and audit log repository methods
- Update quiz repositories and service to use correct field names

## Testing
- `./gradlew clean bootRun` *(fails: query creation exception)*

------
https://chatgpt.com/codex/tasks/task_b_68aac5af4dd0832497359e100931e652