### PR TITLE
fix: add version column to core tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 - Java は [Amazon Corretto](https://aws.amazon.com/corretto/) を使用
 - IDE は [Pleiades](https://pleiades.io/) を推奨
 
-## 進捗状況（2025-08-22時点）
+## 進捗状況（2025-08-25時点）
 - **全体進捗:** 56%
 - **月別ページ:** 100%
 - **週別ページ:** 100%
@@ -98,6 +98,7 @@
 - バックエンド：講義チャプター管理APIを再導入し、新スキーマに対応
 - バックエンド：lecturesテーブルにday_id等を追加し、全54講義データを投入
 - バックエンド：mock_test_bankテーブルにdifficulty_levelカラムを追加
+- バックエンド：months・weeks・daysテーブルにversionカラムを追加しスキーマ整合性を確保
 - バックエンド：外部キー命名とCOMMENT記述ルールを追加
 - バックエンド：V001～V008のDDLをV000とschema.sqlに統合
 - バックエンド：統合済みのV001～V003マイグレーションファイルを削除し、V008のDDLを移行

--- a/progress_and_planning.html
+++ b/progress_and_planning.html
@@ -274,6 +274,10 @@
 
         <div class="bg-white rounded shadow p-4 mb-4">
 <h2 class="fs-3 fw-bold text-custom-blue mb-4">重要な変更履歴</h2>
+            <div class="bg-success bg-opacity-10 border-start border-4 border-success p-3 mb-3">
+                <h3 class="fw-bold mb-2"><i class="fas fa-check-circle text-success me-2"></i>2025-08-25: バージョン列の追加</h3>
+                <p class="text-muted small mb-0">months、weeks、days テーブルに version 列を追加し、起動時のスキーマ検証エラーを解消。</p>
+            </div>
             <div class="bg-secondary bg-opacity-10 border-start border-4 border-secondary p-3 mb-3">
                 <h3 class="fw-bold mb-2"><i class="fas fa-tools text-secondary me-2"></i>2025-08-24: 初期データマイグレーション修正</h3>
                 <p class="text-muted small mb-0">instructors初期データから存在しないexperience_yearsカラムを削除し、スキーマ整合性を確保。</p>

--- a/src/main/resources/db/migration/V000__Create_Users_And_Companies.sql
+++ b/src/main/resources/db/migration/V000__Create_Users_And_Companies.sql
@@ -150,6 +150,7 @@ CREATE TABLE months (
     start_date DATE,
     end_date DATE,
     is_active BOOLEAN DEFAULT true,
+    version BIGINT DEFAULT 0 NOT NULL,
     created_by BIGINT REFERENCES users(id) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_by BIGINT REFERENCES users(id) NOT NULL,
@@ -165,6 +166,7 @@ COMMENT ON COLUMN months.duration_weeks IS '学習期間（週数）';
 COMMENT ON COLUMN months.start_date IS '開始日（月の開始予定日）';
 COMMENT ON COLUMN months.end_date IS '終了日（月の終了予定日）';
 COMMENT ON COLUMN months.is_active IS '有効状態（月の使用可否）';
+COMMENT ON COLUMN months.version IS 'バージョン（楽観ロック用）';
 COMMENT ON COLUMN months.created_at IS '作成日時（レコード作成時刻）';
 COMMENT ON COLUMN months.created_by IS '作成者（レコード作成したユーザーID）';
 COMMENT ON COLUMN months.updated_at IS '更新日時（レコード更新時刻）';
@@ -180,6 +182,7 @@ CREATE TABLE weeks (
     start_date DATE,
     end_date DATE,
     is_active BOOLEAN DEFAULT true,
+    version BIGINT DEFAULT 0 NOT NULL,
     created_by BIGINT REFERENCES users(id) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_by BIGINT REFERENCES users(id) NOT NULL,
@@ -194,6 +197,7 @@ COMMENT ON COLUMN weeks.description IS '説明（週の学習内容説明）';
 COMMENT ON COLUMN weeks.start_date IS '開始日（週の開始予定日）';
 COMMENT ON COLUMN weeks.end_date IS '終了日（週の終了予定日）';
 COMMENT ON COLUMN weeks.is_active IS '有効状態（週の使用可否）';
+COMMENT ON COLUMN weeks.version IS 'バージョン（楽観ロック用）';
 COMMENT ON COLUMN weeks.created_at IS '作成日時（レコード作成時刻）';
 COMMENT ON COLUMN weeks.created_by IS '作成者（レコード作成したユーザーID）';
 COMMENT ON COLUMN weeks.updated_at IS '更新日時（レコード更新時刻）';
@@ -208,6 +212,7 @@ CREATE TABLE days (
     description TEXT,
     scheduled_date DATE,
     is_active BOOLEAN DEFAULT true,
+    version BIGINT DEFAULT 0 NOT NULL,
     created_by BIGINT REFERENCES users(id) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_by BIGINT REFERENCES users(id) NOT NULL,
@@ -221,6 +226,7 @@ COMMENT ON COLUMN days.day_name IS '日名称（日の表示名）';
 COMMENT ON COLUMN days.description IS '説明（日の学習内容説明）';
 COMMENT ON COLUMN days.scheduled_date IS '予定日（日の実施予定日）';
 COMMENT ON COLUMN days.is_active IS '有効状態（日の使用可否）';
+COMMENT ON COLUMN days.version IS 'バージョン（楽観ロック用）';
 COMMENT ON COLUMN days.created_at IS '作成日時（レコード作成時刻）';
 COMMENT ON COLUMN days.created_by IS '作成者（レコード作成したユーザーID）';
 COMMENT ON COLUMN days.updated_at IS '更新日時（レコード更新時刻）';

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -150,6 +150,7 @@ CREATE TABLE months (
     start_date DATE,
     end_date DATE,
     is_active BOOLEAN DEFAULT true,
+    version BIGINT DEFAULT 0 NOT NULL,
     created_by BIGINT REFERENCES users(id) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_by BIGINT REFERENCES users(id) NOT NULL,
@@ -165,6 +166,7 @@ COMMENT ON COLUMN months.duration_weeks IS '学習期間（週数）';
 COMMENT ON COLUMN months.start_date IS '開始日（月の開始予定日）';
 COMMENT ON COLUMN months.end_date IS '終了日（月の終了予定日）';
 COMMENT ON COLUMN months.is_active IS '有効状態（月の使用可否）';
+COMMENT ON COLUMN months.version IS 'バージョン（楽観ロック用）';
 COMMENT ON COLUMN months.created_at IS '作成日時（レコード作成時刻）';
 COMMENT ON COLUMN months.created_by IS '作成者（レコード作成したユーザーID）';
 COMMENT ON COLUMN months.updated_at IS '更新日時（レコード更新時刻）';
@@ -180,6 +182,7 @@ CREATE TABLE weeks (
     start_date DATE,
     end_date DATE,
     is_active BOOLEAN DEFAULT true,
+    version BIGINT DEFAULT 0 NOT NULL,
     created_by BIGINT REFERENCES users(id) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_by BIGINT REFERENCES users(id) NOT NULL,
@@ -194,6 +197,7 @@ COMMENT ON COLUMN weeks.description IS '説明（週の学習内容説明）';
 COMMENT ON COLUMN weeks.start_date IS '開始日（週の開始予定日）';
 COMMENT ON COLUMN weeks.end_date IS '終了日（週の終了予定日）';
 COMMENT ON COLUMN weeks.is_active IS '有効状態（週の使用可否）';
+COMMENT ON COLUMN weeks.version IS 'バージョン（楽観ロック用）';
 COMMENT ON COLUMN weeks.created_at IS '作成日時（レコード作成時刻）';
 COMMENT ON COLUMN weeks.created_by IS '作成者（レコード作成したユーザーID）';
 COMMENT ON COLUMN weeks.updated_at IS '更新日時（レコード更新時刻）';
@@ -208,6 +212,7 @@ CREATE TABLE days (
     description TEXT,
     scheduled_date DATE,
     is_active BOOLEAN DEFAULT true,
+    version BIGINT DEFAULT 0 NOT NULL,
     created_by BIGINT REFERENCES users(id) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_by BIGINT REFERENCES users(id) NOT NULL,
@@ -221,6 +226,7 @@ COMMENT ON COLUMN days.day_name IS '日名称（日の表示名）';
 COMMENT ON COLUMN days.description IS '説明（日の学習内容説明）';
 COMMENT ON COLUMN days.scheduled_date IS '予定日（日の実施予定日）';
 COMMENT ON COLUMN days.is_active IS '有効状態（日の使用可否）';
+COMMENT ON COLUMN days.version IS 'バージョン（楽観ロック用）';
 COMMENT ON COLUMN days.created_at IS '作成日時（レコード作成時刻）';
 COMMENT ON COLUMN days.created_by IS '作成者（レコード作成したユーザーID）';
 COMMENT ON COLUMN days.updated_at IS '更新日時（レコード更新時刻）';


### PR DESCRIPTION
## Summary
- add `version` column to months, weeks, days tables in schema and migration
- document schema update in progress_and_planning and README

## Testing
- `./gradlew build` *(fails: 40 tests completed, 8 failed)*

------
https://chatgpt.com/codex/tasks/task_b_68abd701f56c8324857a29ffe8efb5d3