### PR TITLE
Dayページから講義スライドを開けるよう修正

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
@@ -43,6 +43,17 @@ public class LectureViewController extends AbstractController {
     private MonthService monthService;
 
     /**
+     * 静的講義スライドを表示します。
+     *
+     * @param number 講義番号
+     * @return テンプレート
+     */
+    @GetMapping("/lecture{number}.html")
+    public String lectureSlide(@PathVariable Long number) {
+        return "lecture/lecture" + number;
+    }
+
+    /**
      * 講義詳細を表示します。
      *
      * @param id 講義ID

--- a/src/main/resources/templates/day.html
+++ b/src/main/resources/templates/day.html
@@ -20,8 +20,9 @@
             <div class="card-header">講義一覧</div>
             <div class="card-body">
                 <ul class="list-group list-group-flush">
-                    <li class="list-group-item" th:each="lecture : ${lectures}">
+                    <li class="list-group-item d-flex justify-content-between align-items-center" th:each="lecture : ${lectures}">
                         <a th:href="@{/lecture/{id}(id=${lecture.id})}" th:text="${lecture.title}"></a>
+                        <a th:href="@{/lecture/lecture{num}.html(num=${lecture.lectureNumber})}" target="_blank" class="btn btn-warning btn-sm ms-2">講義スライドを開く</a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
## Summary
- Dayページに講義スライドを開くボタンを追加
- lectureスライド用のコントローラを追加し静的HTMLを表示

## Testing
- `./gradlew build` (failed: there were failing tests)
- `./gradlew build -x test`
- `xdg-open src/main/resources/templates/index.html` (command not found)

------
https://chatgpt.com/codex/tasks/task_b_68abd9ed80708324b52a7348af15d665