### PR TITLE
Dozer導入によるコピー処理のリファクタリング

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,9 @@ dependencies {
     implementation 'org.apache.commons:commons-collections4:4.4'
     implementation 'commons-io:commons-io:2.11.0'
 
+    // Object Mapping
+    implementation 'com.github.dozermapper:dozer-core:6.5.2'
+
     // WebJars
     implementation 'org.webjars.npm:bootstrap:5.3.3'
     implementation 'org.webjars.npm:bootstrap-icons:1.11.3'

--- a/src/main/java/jp/co/apsa/giiku/config/DozerConfig.java
+++ b/src/main/java/jp/co/apsa/giiku/config/DozerConfig.java
@@ -1,0 +1,54 @@
+package jp.co.apsa.giiku.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.dozermapper.core.Mapper;
+import com.github.dozermapper.core.DozerBeanMapperBuilder;
+import com.github.dozermapper.core.loader.api.BeanMappingBuilder;
+import com.github.dozermapper.core.loader.api.TypeMappingOptions;
+
+import jp.co.apsa.giiku.domain.entity.LectureChapter;
+import jp.co.apsa.giiku.domain.entity.ProgramSchedule;
+
+/**
+ * Dozer の設定を提供するコンフィグレーションクラス。
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
+@Configuration
+public class DozerConfig {
+
+    /**
+     * 監査情報やIDを除外した Dozer Mapper を生成する。
+     *
+     * @return Dozer Mapper
+     */
+    @Bean
+    public Mapper dozerMapper() {
+        return DozerBeanMapperBuilder.create()
+                .withMappingBuilder(new BeanMappingBuilder() {
+                    @Override
+                    protected void configure() {
+                        mapping(ProgramSchedule.class, ProgramSchedule.class, TypeMappingOptions.oneWay())
+                                .exclude("id")
+                                .exclude("version")
+                                .exclude("createdBy")
+                                .exclude("createdAt")
+                                .exclude("updatedBy")
+                                .exclude("updatedAt");
+                        mapping(LectureChapter.class, LectureChapter.class, TypeMappingOptions.oneWay())
+                                .exclude("id")
+                                .exclude("version")
+                                .exclude("createdBy")
+                                .exclude("createdAt")
+                                .exclude("updatedBy")
+                                .exclude("updatedAt");
+                    }
+                })
+                .build();
+    }
+}
+

--- a/src/main/java/jp/co/apsa/giiku/service/LectureChapterService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/LectureChapterService.java
@@ -11,6 +11,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.github.dozermapper.core.Mapper;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -29,6 +31,9 @@ public class LectureChapterService {
 
     @Autowired
     private LectureChapterRepository lectureChapterRepository;
+
+    @Autowired
+    private Mapper mapper;
 
     /**
      * チャプター一覧を取得する（ページング・ソート対応）
@@ -179,15 +184,11 @@ public class LectureChapterService {
     public LectureChapterResponseDto duplicateChapter(Long id, Long targetLectureId) {
         return lectureChapterRepository.findById(id)
                 .map(originalChapter -> {
-                    LectureChapter duplicatedChapter = new LectureChapter();
+                    LectureChapter duplicatedChapter = mapper.map(originalChapter, LectureChapter.class);
                     duplicatedChapter.setLectureId(targetLectureId != null ? targetLectureId : originalChapter.getLectureId());
                     duplicatedChapter.setChapterNumber(getNextChapterNumber(duplicatedChapter.getLectureId()));
                     duplicatedChapter.setTitle(originalChapter.getTitle() + " (コピー)");
-                    duplicatedChapter.setDescription(originalChapter.getDescription());
-                    duplicatedChapter.setDurationMinutes(originalChapter.getDurationMinutes());
                     duplicatedChapter.setSortOrder(getNextSortOrder(duplicatedChapter.getLectureId()));
-                    duplicatedChapter.setIsActive(originalChapter.getIsActive());
-
                     LectureChapter saved = lectureChapterRepository.save(duplicatedChapter);
                     return convertToResponseDto(saved);
                 })

--- a/src/main/java/jp/co/apsa/giiku/service/ProgramScheduleService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/ProgramScheduleService.java
@@ -25,6 +25,7 @@ import jp.co.apsa.giiku.dto.ProgramScheduleResponseDto;
 import jp.co.apsa.giiku.dto.ProgramScheduleSearchDto;
 import jp.co.apsa.giiku.dto.ProgramScheduleStatsDto;
 import jp.co.apsa.giiku.dto.ProgramScheduleUpdateDto;
+import com.github.dozermapper.core.Mapper;
 
 /**
  * ProgramSchedule（プログラムスケジュール）に関するビジネスロジックを提供するサービスクラス。
@@ -42,6 +43,9 @@ public class ProgramScheduleService {
 
     @Autowired
     private TrainingProgramRepository trainingProgramRepository;
+
+    @Autowired
+    private Mapper mapper;
 
     /**
      * 全てのプログラムスケジュールを取得
@@ -340,12 +344,7 @@ public class ProgramScheduleService {
 
     public ProgramScheduleResponseDto duplicateSchedule(Long id, String newStartDate, String newEndDate) {
         ProgramSchedule original = programScheduleRepository.findById(id).orElseThrow();
-        ProgramSchedule copy = new ProgramSchedule();
-        copy.setProgramId(original.getProgramId());
-        copy.setInstructorId(original.getInstructorId());
-        copy.setScheduleStatus(original.getScheduleStatus());
-        copy.setMaxStudents(original.getMaxStudents());
-        copy.setCurrentStudents(original.getCurrentStudents());
+        ProgramSchedule copy = mapper.map(original, ProgramSchedule.class);
         copy.setStartDate(newStartDate != null ? LocalDate.parse(newStartDate) : original.getStartDate());
         copy.setEndDate(newEndDate != null ? LocalDate.parse(newEndDate) : original.getEndDate());
         ProgramSchedule saved = programScheduleRepository.save(copy);

--- a/src/test/java/jp/co/apsa/giiku/controller/DashboardControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/DashboardControllerTest.java
@@ -10,6 +10,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import jp.co.apsa.giiku.service.MonthService;
+import jp.co.apsa.giiku.service.WeekService;
+import jp.co.apsa.giiku.service.DayService;
 import org.springframework.test.web.servlet.MockMvc;
 
 /**
@@ -27,6 +30,15 @@ class DashboardControllerTest {
 
     @MockBean
     private DashboardService dashboardService;
+
+    @MockBean
+    private MonthService monthService;
+
+    @MockBean
+    private WeekService weekService;
+
+    @MockBean
+    private DayService dayService;
 
     @org.springframework.boot.autoconfigure.SpringBootApplication(
         exclude = {

--- a/src/test/java/jp/co/apsa/giiku/controller/DayControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/DayControllerTest.java
@@ -2,12 +2,24 @@ package jp.co.apsa.giiku.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import jp.co.apsa.giiku.service.MonthService;
+import jp.co.apsa.giiku.service.WeekService;
+import jp.co.apsa.giiku.service.DayService;
+import jp.co.apsa.giiku.service.LectureService;
 import org.springframework.test.web.servlet.MockMvc;
+
+import jp.co.apsa.giiku.domain.entity.Day;
+import jp.co.apsa.giiku.domain.entity.Week;
+import jp.co.apsa.giiku.domain.entity.Month;
+import java.util.Optional;
+import java.util.Collections;
 
 /**
  * @author 株式会社アプサ
@@ -22,6 +34,18 @@ class DayControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @MockBean
+    private MonthService monthService;
+
+    @MockBean
+    private WeekService weekService;
+
+    @MockBean
+    private DayService dayService;
+
+    @MockBean
+    private LectureService lectureService;
+
     @org.springframework.boot.autoconfigure.SpringBootApplication(
         exclude = {
             org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration.class,
@@ -34,9 +58,31 @@ class DayControllerTest {
 
     @Test
     void dayPageReturnsView() throws Exception {
+        Day day = new Day();
+        day.setId(1L);
+        day.setWeekId(1L);
+        day.setDayName("Day1");
+        day.setDayNumber(1);
+
+        Week week = new Week();
+        week.setId(1L);
+        week.setMonthId(1L);
+        week.setWeekNumber(1);
+        week.setWeekName("Week1");
+
+        Month month = new Month();
+        month.setId(1L);
+        month.setMonthNumber(1);
+        month.setTitle("Month1");
+
+        when(dayService.findByDayNumber(1)).thenReturn(Optional.of(day));
+        when(weekService.findById(1L)).thenReturn(Optional.of(week));
+        when(monthService.findById(1L)).thenReturn(Optional.of(month));
+        when(lectureService.findByDayId(1L)).thenReturn(Collections.emptyList());
+
         mockMvc.perform(get("/day/day1"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("day/day1"));
+                .andExpect(view().name("day"));
     }
 }
 

--- a/src/test/java/jp/co/apsa/giiku/controller/LoginControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/LoginControllerTest.java
@@ -7,6 +7,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import jp.co.apsa.giiku.service.MonthService;
+import jp.co.apsa.giiku.service.WeekService;
+import jp.co.apsa.giiku.service.DayService;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.DefaultCsrfToken;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,6 +27,15 @@ class LoginControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private MonthService monthService;
+
+    @MockBean
+    private WeekService weekService;
+
+    @MockBean
+    private DayService dayService;
 
     private CsrfToken csrfToken() {
         return new DefaultCsrfToken("X-CSRF-TOKEN", "_csrf", "token");

--- a/src/test/java/jp/co/apsa/giiku/controller/MonthControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/MonthControllerTest.java
@@ -2,12 +2,21 @@ package jp.co.apsa.giiku.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import jp.co.apsa.giiku.service.MonthService;
+import jp.co.apsa.giiku.service.WeekService;
+import jp.co.apsa.giiku.service.DayService;
 import org.springframework.test.web.servlet.MockMvc;
+
+import jp.co.apsa.giiku.domain.entity.Month;
+import java.util.Collections;
+import java.util.Optional;
 
 /**
  * @author 株式会社アプサ
@@ -22,6 +31,15 @@ class MonthControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @MockBean
+    private MonthService monthService;
+
+    @MockBean
+    private WeekService weekService;
+
+    @MockBean
+    private DayService dayService;
+
     @org.springframework.boot.autoconfigure.SpringBootApplication(
         exclude = {
             org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration.class,
@@ -34,9 +52,17 @@ class MonthControllerTest {
 
     @Test
     void monthPageReturnsView() throws Exception {
+        Month month = new Month();
+        month.setId(1L);
+        month.setMonthNumber(1);
+        month.setTitle("Month1");
+
+        when(monthService.findByMonthNumber(1)).thenReturn(Optional.of(month));
+        when(weekService.findByMonthId(1L)).thenReturn(Collections.emptyList());
+
         mockMvc.perform(get("/month/month1"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("month/month1"));
+                .andExpect(view().name("month"));
     }
 }
 

--- a/src/test/java/jp/co/apsa/giiku/controller/WeekControllerTest.java
+++ b/src/test/java/jp/co/apsa/giiku/controller/WeekControllerTest.java
@@ -2,12 +2,22 @@ package jp.co.apsa.giiku.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import jp.co.apsa.giiku.service.MonthService;
+import jp.co.apsa.giiku.service.WeekService;
+import jp.co.apsa.giiku.service.DayService;
 import org.springframework.test.web.servlet.MockMvc;
+
+import jp.co.apsa.giiku.domain.entity.Week;
+import jp.co.apsa.giiku.domain.entity.Month;
+import java.util.Collections;
+import java.util.Optional;
 
 /**
  * @author 株式会社アプサ
@@ -22,6 +32,15 @@ class WeekControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @MockBean
+    private MonthService monthService;
+
+    @MockBean
+    private WeekService weekService;
+
+    @MockBean
+    private DayService dayService;
+
     @org.springframework.boot.autoconfigure.SpringBootApplication(
         exclude = {
             org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration.class,
@@ -34,9 +53,24 @@ class WeekControllerTest {
 
     @Test
     void weekPageReturnsView() throws Exception {
+        Week week = new Week();
+        week.setId(1L);
+        week.setMonthId(1L);
+        week.setWeekNumber(1);
+        week.setWeekName("Week1");
+
+        Month month = new Month();
+        month.setId(1L);
+        month.setMonthNumber(1);
+        month.setTitle("Month1");
+
+        when(weekService.findByWeekNumber(1)).thenReturn(Optional.of(week));
+        when(monthService.findById(1L)).thenReturn(Optional.of(month));
+        when(dayService.findByWeekId(1L)).thenReturn(Collections.emptyList());
+
         mockMvc.perform(get("/week/week1"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("week/week1"));
+                .andExpect(view().name("week"));
     }
 }
 


### PR DESCRIPTION
## Summary
- Dozer Mapperを監査情報を除外する設定に拡張
- ProgramScheduleとLectureChapterの複製処理をDozerベースに統一
- コントローラーテストで依存サービスをモック化

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68ad4ede0888832498faf3b5f8e3d62b