### PR TITLE
講義テンプレートをBootstrapに統一

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     implementation 'org.webjars.npm:react-dom:18.2.0'
     implementation 'org.webjars.npm:babel__standalone:7.21.2'
     implementation 'org.webjars.npm:js-tokens:4.0.0'
+    implementation 'org.webjars.npm:prismjs:1.29.0'
     implementation 'org.webjars:webjars-locator-core'
 
     // Lombok

--- a/src/main/resources/static/css/lecture.css
+++ b/src/main/resources/static/css/lecture.css
@@ -1,0 +1,60 @@
+.highlight {
+    background-color: #fef08a;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-weight: 600;
+}
+
+.code-block {
+    background-color: #1e293b;
+    color: #e2e8f0;
+    padding: 1rem;
+    border-radius: 8px;
+    overflow-x: auto;
+    font-family: 'Courier New', monospace;
+}
+
+.answer-section,
+.answer-content {
+    display: none;
+    margin-top: 1rem;
+    padding: 1rem;
+    background-color: #f0fdf4;
+    border-radius: 8px;
+    border-left: 4px solid #22c55e;
+}
+
+.answer-content.show {
+    display: block;
+}
+
+.instructor-note {
+    background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+    border-left: 4px solid #f59e0b;
+    padding: 1rem;
+    margin: 1rem 0;
+    border-radius: 8px;
+}
+
+.student-support {
+    background: linear-gradient(135deg, #dbeafe 0%, #bfdbfe 100%);
+    border-left: 4px solid #3b82f6;
+    padding: 1rem;
+    margin: 1rem 0;
+    border-radius: 8px;
+}
+
+.fixed-nav {
+    backdrop-filter: blur(10px);
+    background-color: rgba(255, 255, 255, 0.95);
+}
+
+.nav-link:hover {
+    background-color: rgba(59, 130, 246, 0.1);
+}
+
+.breadcrumb-separator::after {
+    content: ">";
+    margin: 0 8px;
+    color: #9CA3AF;
+}

--- a/src/main/resources/templates/_layouts/base.html
+++ b/src/main/resources/templates/_layouts/base.html
@@ -10,6 +10,7 @@
     <link href="../static/css/lib/bootstrap-icons.css" th:href="@{/webjars/bootstrap-icons/font/bootstrap-icons.css}" rel="stylesheet">
     <link href="/webjars/fortawesome__fontawesome-free/css/all.min.css" th:href="@{/webjars/fortawesome__fontawesome-free/css/all.min.css}" rel="stylesheet">
     <link th:href="@{/css/style.css}" rel="stylesheet">
+    <link th:href="@{/css/lecture.css}" rel="stylesheet">
 </head>
 <body>
     <div th:replace="~{_fragments/headers :: global}"></div>

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -6,50 +6,48 @@
 <head>
     <meta charset="UTF-8">
     <title th:text="${lecture.title}">Lecture</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/js/all.min.js"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/themes/prism.min.css">
+    <link rel="stylesheet" th:href="@{/webjars/prismjs/themes/prism.min.css}">
 </head>
-<body class="bg-gray-50 text-gray-900 leading-relaxed">
+<body class="bg-light text-dark">
 
 <div layout:fragment="pageheader"
      th:replace="~{_fragments/headers :: page(title=${pageTitle}, breadcrumb=${breadcrumbs})}"></div>
 
 <section layout:fragment="content">
-    <main class="pt-32">
+    <main class="pt-5">
         <!-- 講義ヘッダー -->
-        <header class="bg-blue-800 text-white py-4 shadow-lg">
-            <div class="container mx-auto px-4">
-                <h1 class="text-2xl md:text-3xl font-bold text-center mb-2">
-                    <i class="fas fa-coffee mr-2"></i>
+        <header class="bg-primary text-white py-4 shadow">
+            <div class="container px-4">
+                <h1 class="text-center fw-bold mb-2">
+                    <i class="fas fa-coffee me-2"></i>
                     <span th:text="${lecture.title}">講義タイトル</span>
                 </h1>
-                <p class="text-center text-blue-200 text-lg" th:text="${lecture.description}">講義説明</p>
-                <div class="mt-3 text-center text-sm">
-                    <span class="bg-blue-700 px-3 py-1 rounded-full mr-2">
+                <p class="text-center text-light fs-5" th:text="${lecture.description}">講義説明</p>
+                <div class="mt-3 text-center small">
+                    <span class="badge bg-secondary me-2">
                         所要時間: <span th:text="${lecture.durationMinutes}">90</span>分
                     </span>
-                    <span class="bg-blue-700 px-3 py-1 rounded-full mr-2"
+                    <span class="badge bg-secondary me-2"
                           th:if="${lecture.difficultyLevel}">
                         レベル: <span th:text="${lecture.difficultyLevel}">初級</span>
                     </span>
-                    <span class="bg-blue-700 px-3 py-1 rounded-full">
+                    <span class="badge bg-secondary">
                         講義番号: <span th:text="${lecture.lectureNumber}">1</span>
                     </span>
                 </div>
             </div>
         </header>
 
-        <div class="container mx-auto px-4 py-8 max-w-6xl">
-
+        <div class="container px-4 py-4">
             <!-- 学習目標セクション -->
-            <section class="bg-white rounded-lg shadow-lg p-6 mb-8" th:if="${goals != null and !goals.isEmpty()}">
-                <h2 class="text-2xl font-bold text-blue-800 mb-4">
-                    <i class="fas fa-target mr-2"></i>本日の学習目標
+            <section class="bg-white rounded shadow p-4 mb-4" th:if="${goals != null and !goals.isEmpty()}">
+                <h2 class="fw-bold text-primary mb-4">
+                    <i class="fas fa-target me-2"></i>本日の学習目標
                 </h2>
-                <div class="space-y-4">
+                <div class="d-flex flex-column gap-3">
                     <div th:each="goal : ${goals}">
-                        <div class="flex items-start">
-                            <i class="fas fa-check-circle text-blue-500 mr-2 mt-1"></i>
+                        <div class="d-flex align-items-start">
+                            <i class="fas fa-check-circle text-primary me-2 mt-1"></i>
                             <span th:text="${goal.goalDescription}">学習目標項目</span>
                         </div>
                     </div>
@@ -57,60 +55,60 @@
             </section>
 
             <!-- コンテンツチャプターセクション -->
-            <div th:each="chapter, iterStat : ${contentChapters}" class="mb-8" th:if="${contentChapters != null and !contentChapters.isEmpty()}">
-                <section class="bg-white rounded-lg shadow-lg p-6">
-                    <h2 class="text-2xl font-bold mb-4 text-purple-800"
+            <div th:each="chapter, iterStat : ${contentChapters}" class="mb-4" th:if="${contentChapters != null and !contentChapters.isEmpty()}">
+                <section class="bg-white rounded shadow p-4">
+                    <h2 class="fw-bold mb-4 text-primary"
                         th:text="${chapter.chapterNumber + '. ' + chapter.title}">
                         チャプタータイトル
                     </h2>
 
                     <!-- チャプター説明 -->
-                    <div th:if="${chapter.description}" class="mb-6">
+                    <div th:if="${chapter.description}" class="mb-4">
                         <p th:text="${chapter.description}">チャプター説明</p>
                     </div>
 
                     <!-- チャプターの所要時間 -->
                     <div th:if="${chapter.durationMinutes}" class="mb-4">
-                        <span class="inline-block bg-blue-100 text-blue-800 text-sm px-3 py-1 rounded-full">
+                        <span class="badge bg-secondary">
                             所要時間: <span th:text="${chapter.durationMinutes}">30</span>分
                         </span>
                     </div>
 
                     <!-- このチャプターのコンテンツブロック -->
                     <div th:with="blocks=${chapterContentBlocks[chapter.id]}" th:if="${blocks != null and !blocks.isEmpty()}">
-                        <h3 class="text-lg font-semibold mb-4 text-gray-700">コンテンツ</h3>
-                        <div th:each="block : ${blocks}" class="mb-6 p-4 border rounded-lg">
-                            <h4 class="font-medium text-gray-800 mb-2" th:text="${block.title}">ブロックタイトル</h4>
+                        <h3 class="fw-semibold mb-4 text-secondary">コンテンツ</h3>
+                        <div th:each="block : ${blocks}" class="mb-4 p-4 border rounded">
+                            <h4 class="fw-semibold text-dark mb-2" th:text="${block.title}">ブロックタイトル</h4>
 
-                            <div class="bg-gray-50 p-3 rounded mb-3">
-                                <span class="text-xs font-medium text-gray-500 uppercase tracking-wide"
+                            <div class="bg-light p-3 rounded mb-3">
+                                <span class="fw-semibold text-muted text-uppercase small"
                                       th:text="${block.blockType}">ブロック種別</span>
                             </div>
 
-                            <div th:if="${block.content}" class="prose">
+                            <div th:if="${block.content}">
                                 <div th:switch="${block.blockType}">
                                     <!-- テキストコンテンツ -->
-                                    <div th:case="'text'" class="prose">
+                                    <div th:case="'text'">
                                         <p th:utext="${block.content}">コンテンツ内容</p>
                                     </div>
 
                                     <!-- コードブロック -->
-                                    <div th:case="'code'" class="code-highlight rounded-lg p-4 mb-4 bg-gray-900">
-                                        <pre class="text-white overflow-x-auto"><code th:text="${block.content}">コード内容</code></pre>
+                                    <div th:case="'code'" class="code-block mb-4">
+                                        <pre><code th:text="${block.content}">コード内容</code></pre>
                                     </div>
 
                                     <!-- 画像 -->
                                     <div th:case="'image'" class="text-center">
-                                        <img th:src="${block.content}" th:alt="${block.title}" class="max-w-full h-auto mx-auto rounded">
+                                        <img th:src="${block.content}" th:alt="${block.title}" class="img-fluid mx-auto d-block rounded">
                                     </div>
 
                                     <!-- リスト -->
-                                    <div th:case="'list'" class="prose">
+                                    <div th:case="'list'">
                                         <div th:utext="${block.content}">リスト内容</div>
                                     </div>
 
                                     <!-- その他のコンテンツ -->
-                                    <div th:case="*" class="prose">
+                                    <div th:case="*">
                                         <div th:utext="${block.content}">その他のコンテンツ</div>
                                     </div>
                                 </div>
@@ -119,52 +117,40 @@
                     </div>
 
                     <!-- コンテンツブロックがない場合のメッセージ -->
-                    <div th:if="${chapterContentBlocks[chapter.id] == null or chapterContentBlocks[chapter.id].isEmpty()}"
-                         class="bg-gray-50 p-4 rounded-lg text-center text-gray-500">
-                        <p>このチャプターのコンテンツは準備中です。</p>
+                    <div th:if="${chapterContentBlocks[chapter.id] == null || chapterContentBlocks[chapter.id].isEmpty()}">
+                        <p>この講義のコンテンツは現在準備中です。しばらくお待ちください。</p>
                     </div>
                 </section>
             </div>
 
-            <!-- チャプターがない場合のメッセージ -->
-            <section th:if="${contentChapters == null or contentChapters.isEmpty()}"
-                     class="bg-white rounded-lg shadow-lg p-6 mb-8">
-                <div class="text-center text-gray-500">
-                    <i class="fas fa-book-open text-4xl mb-4"></i>
-                    <h3 class="text-xl font-semibold mb-2">コンテンツ準備中</h3>
-                    <p>この講義のコンテンツは現在準備中です。しばらくお待ちください。</p>
-                </div>
-            </section>
-
             <!-- 演習問題セクション -->
-            <section th:if="${exercises != null and !exercises.isEmpty()}" class="bg-white rounded-lg shadow-lg p-6 mb-8">
-                <h2 class="text-2xl font-bold text-indigo-800 mb-4">
-                    <i class="fas fa-dumbbell mr-2"></i>演習問題
+            <section th:if="${exercises != null and !exercises.isEmpty()}" class="bg-white rounded shadow p-4 mb-4">
+                <h2 class="fw-bold text-primary mb-4">
+                    <i class="fas fa-dumbbell me-2"></i>演習問題
                 </h2>
 
-                <div th:each="exercise, exStat : ${exercises}" class="border border-gray-200 rounded-lg p-4 mb-6">
-                    <h3 class="font-bold text-blue-600 mb-3"
+                <div th:each="exercise, exStat : ${exercises}" class="border rounded p-4 mb-4">
+                    <h3 class="fw-bold text-primary mb-3"
                         th:text="${'演習問題' + (exStat.count) + ': ' + exercise.title}">演習問題タイトル</h3>
                     <p class="mb-3" th:utext="${exercise.description}">問題説明</p>
 
-                    <ol th:if="${exercise.questions}" class="space-y-2 mb-4">
+                    <ol th:if="${exercise.questions}" class="mb-4 ps-3">
                         <li th:each="question, qStat : ${exercise.questions}"
-                            th:text="${(qStat.count) + '. ' + question}">質問内容</li>
+                            th:text="${(qStat.count) + '. ' + question}" class="mb-2">質問内容</li>
                     </ol>
 
                     <button th:onclick="'toggleAnswer(\'answer' + ${exStat.count} + '\')'"
-                            class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded transition-colors">
-                        <i class="fas fa-eye mr-2"></i>回答例を表示
+                            class="btn btn-primary">
+                        <i class="fas fa-eye me-2"></i>回答例を表示
                     </button>
 
                     <div sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')"
                          th:id="'answer' + ${exStat.count}"
-                         class="answer-content mt-4 bg-blue-50 border-l-4 border-blue-400 p-4 rounded"
-                         style="display: none;">
-                        <h4 class="font-semibold mb-2">回答例：</h4>
-                        <div class="space-y-3 text-sm">
+                         class="answer-content">
+                        <h4 class="fw-semibold mb-2">回答例：</h4>
+                        <div class="d-flex flex-column gap-3 small">
                             <div th:each="answer : ${exercise.answers}">
-                                <p class="font-medium" th:text="${answer.question}">質問</p>
+                                <p class="fw-semibold" th:text="${answer.question}">質問</p>
                                 <p th:utext="${answer.answer}">回答</p>
                             </div>
                         </div>
@@ -173,18 +159,18 @@
             </section>
 
             <!-- 追加リソース -->
-            <section th:if="${additionalResources != null and !additionalResources.isEmpty()}" class="bg-white rounded-lg shadow-lg p-6 mb-8">
-                <h2 class="text-2xl font-bold text-purple-800 mb-4">
-                    <i class="fas fa-link mr-2"></i>追加学習リソース
+            <section th:if="${additionalResources != null and !additionalResources.isEmpty()}" class="bg-white rounded shadow p-4 mb-4">
+                <h2 class="fw-bold text-primary mb-4">
+                    <i class="fas fa-link me-2"></i>追加学習リソース
                 </h2>
-                <div class="grid md:grid-cols-2 gap-4">
-                    <div th:each="resource : ${additionalResources}">
-                        <div class="border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow">
-                            <h4 class="font-semibold mb-2" th:text="${resource.title}">リソースタイトル</h4>
-                            <p class="text-sm text-gray-600 mb-2" th:text="${resource.description}">説明</p>
+                <div class="row row-cols-1 row-cols-md-2 g-4">
+                    <div th:each="resource : ${additionalResources}" class="col">
+                        <div class="border rounded p-4 h-100">
+                            <h4 class="fw-semibold mb-2" th:text="${resource.title}">リソースタイトル</h4>
+                            <p class="text-muted small mb-2" th:text="${resource.description}">説明</p>
                             <a th:href="${resource.url}" target="_blank"
-                               class="text-blue-600 hover:text-blue-800 text-sm">
-                                <i class="fas fa-external-link-alt mr-1"></i>
+                               class="text-primary small text-decoration-none">
+                                <i class="fas fa-external-link-alt me-1"></i>
                                 <span th:text="${resource.linkText ?: 'リンクを開く'}">リンクテキスト</span>
                             </a>
                         </div>
@@ -193,21 +179,21 @@
             </section>
 
             <!-- ナビゲーション -->
-            <section class="flex justify-between items-center bg-white rounded-lg shadow-lg p-6">
+            <section class="d-flex justify-content-between align-items-center bg-white rounded shadow p-4">
                 <div>
                     <a th:if="${previousLecture}"
                        th:href="@{/lecture/{id}(id=${previousLecture.id})}"
-                       class="inline-flex items-center px-4 py-2 bg-gray-500 text-white rounded hover:bg-gray-600 transition-colors">
-                        <i class="fas fa-arrow-left mr-2"></i>
+                       class="btn btn-secondary d-inline-flex align-items-center px-4 py-2">
+                        <i class="fas fa-arrow-left me-2"></i>
                         前の講義: <span th:text="${previousLecture.title}">前の講義</span>
                     </a>
                 </div>
                 <div>
                     <a th:if="${nextLecture}"
                        th:href="@{/lecture/{id}(id=${nextLecture.id})}"
-                       class="inline-flex items-center px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors">
+                       class="btn btn-primary d-inline-flex align-items-center px-4 py-2">
                         次の講義: <span th:text="${nextLecture.title}">次の講義</span>
-                        <i class="fas fa-arrow-right ml-2"></i>
+                        <i class="fas fa-arrow-right ms-2"></i>
                     </a>
                 </div>
             </section>
@@ -228,10 +214,10 @@
                     const icon = button.querySelector('i');
                     const text = button.querySelector('i + *') || button.childNodes[1];
                     if (isHidden) {
-                        icon.className = 'fas fa-eye-slash mr-2';
+                        icon.className = 'fas fa-eye-slash me-2';
                         text.textContent = '回答例を非表示';
                     } else {
-                        icon.className = 'fas fa-eye mr-2';
+                        icon.className = 'fas fa-eye me-2';
                         text.textContent = '回答例を表示';
                     }
                 }
@@ -240,7 +226,6 @@
 
         // コードブロックの構文ハイライト
         document.addEventListener('DOMContentLoaded', function() {
-            // Prism.jsがロードされている場合のみ実行
             if (typeof Prism !== 'undefined') {
                 Prism.highlightAll();
             }
@@ -248,9 +233,9 @@
     </script>
 
     <!-- Syntax Highlighting -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/prism.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/components/prism-java.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/components/prism-sql.min.js"></script>
+    <script th:src="@{/webjars/prismjs/prism.min.js}"></script>
+    <script th:src="@{/webjars/prismjs/components/prism-java.min.js}"></script>
+    <script th:src="@{/webjars/prismjs/components/prism-sql.min.js}"></script>
 </section>
 </body>
 </html>


### PR DESCRIPTION
## 概要
- lecture.htmlからTailwindクラスを除去しBootstrapユーティリティへ置換
- Prism.jsをWebJar経由で読み込み、依存関係にprismjsを追加

## テスト
- `./gradlew build`
- `curl -I http://localhost:8080/lecture/1`（サーバ未起動のため失敗）

------
https://chatgpt.com/codex/tasks/task_b_68ae30cddbcc8324be0093fcdd467c91