### PR TITLE
feat: improve code block styling for lectures

### DIFF
--- a/src/main/resources/static/css/lecture.css
+++ b/src/main/resources/static/css/lecture.css
@@ -14,6 +14,10 @@
     font-family: 'Courier New', monospace;
 }
 
+.code-block pre {
+    margin-bottom: 0;
+}
+
 .answer-section,
 .answer-content {
     display: none;

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -6,7 +6,7 @@
 <head>
     <meta charset="UTF-8">
     <title th:text="${lecture.title}">Lecture</title>
-    <link rel="stylesheet" th:href="@{/webjars/prismjs/themes/prism.min.css}">
+    <link rel="stylesheet" th:href="@{/webjars/prismjs/1.29.0/themes/prism.min.css}">
 </head>
 <body class="bg-light text-dark">
 
@@ -95,7 +95,7 @@
 
                                         <!-- コードブロック -->
                                         <div th:case="'code'" class="code-block mb-4">
-                                            <pre><code th:text="${block.content}">コード内容</code></pre>
+                                            <pre><code class="language-java" th:text="${block.content}">コード内容</code></pre>
                                         </div>
 
                                         <!-- 画像 -->
@@ -235,9 +235,9 @@
     </script>
 
     <!-- Syntax Highlighting -->
-    <script th:src="@{/webjars/prismjs/prism.min.js}"></script>
-    <script th:src="@{/webjars/prismjs/components/prism-java.min.js}"></script>
-    <script th:src="@{/webjars/prismjs/components/prism-sql.min.js}"></script>
+    <script th:src="@{/webjars/prismjs/1.29.0/prism.min.js}"></script>
+    <script th:src="@{/webjars/prismjs/1.29.0/components/prism-java.min.js}"></script>
+    <script th:src="@{/webjars/prismjs/1.29.0/components/prism-sql.min.js}"></script>
 </section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure PrismJS assets use explicit version paths
- render code blocks with language hints and margin reset

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68ae4e37c3dc8324ac3e800a8baa461e