### PR TITLE
講義ページのチャプター表示を改善

### DIFF
--- a/src/main/resources/static/css/lecture.css
+++ b/src/main/resources/static/css/lecture.css
@@ -7,7 +7,6 @@
 
 .code-block {
     background-color: #1e293b;
-    color: #e2e8f0;
     padding: 1rem;
     border-radius: 8px;
     overflow-x: auto;
@@ -16,6 +15,12 @@
 
 .code-block pre {
     margin-bottom: 0;
+}
+
+.formatted-text {
+    white-space: pre-wrap;
+    font-family: inherit;
+    margin: 0;
 }
 
 .answer-section,

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -90,7 +90,7 @@
                                     <div th:switch="${block.blockType}">
                                         <!-- テキストコンテンツ -->
                                         <div th:case="'text'">
-                                            <p th:utext="${block.content}">コンテンツ内容</p>
+                                            <pre class="formatted-text" th:utext="${block.content}">コンテンツ内容</pre>
                                         </div>
 
                                         <!-- コードブロック -->


### PR DESCRIPTION
## Summary
- テキストブロックを`pre.formatted-text`で表示し改行を保持
- CSSで`formatted-text`にフォント継承と余白リセットを追加

## Testing
- `npm run test:e2e` *(psql: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ae50844c348324b90808ac95598aa7