### PR TITLE
fix: lecture block type case-insensitive

### DIFF
--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -87,7 +87,7 @@
                                 </div>
 
                                 <div th:if="${block.content}">
-                                    <div th:switch="${block.blockType}">
+                                    <div th:switch="${#strings.toLowerCase(block.blockType)}">
                                         <!-- テキストコンテンツ -->
                                         <div th:case="'text'">
                                             <pre class="formatted-text" th:utext="${block.content}">コンテンツ内容</pre>


### PR DESCRIPTION
## Summary
- ensure lecture template block type switch is case-insensitive

## Testing
- `node - <<'NODE' ...` to open index.html with Playwright
- `node - <<'NODE' ...` to check code highlight on lecture.html (Prism not loaded in static file)`

------
https://chatgpt.com/codex/tasks/task_b_68ae579ac0248324adc29af1f681dd42