### PR TITLE
fix: preserve newlines in lecture blocks

### DIFF
--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -105,12 +105,12 @@
 
                                         <!-- リスト -->
                                         <div th:case="'list'">
-                                            <div th:utext="${block.content}">リスト内容</div>
+                                            <pre class="formatted-text" th:utext="${block.content}">リスト内容</pre>
                                         </div>
 
                                         <!-- その他のコンテンツ -->
                                         <div th:case="*">
-                                            <div th:utext="${block.content}">その他のコンテンツ</div>
+                                            <pre class="formatted-text" th:utext="${block.content}">その他のコンテンツ</pre>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- use `<pre class="formatted-text">` for list blocks to retain line breaks
- fallback blocks also render in `<pre>` to keep formatting

## Testing
- `./gradlew build`
- `npx playwright open src/main/resources/templates/index.html` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_b_68ae5cdb78a08324848971d99e0150bb