### PR TITLE
feat: use dark prism theme for lecture code blocks

### DIFF
--- a/src/main/resources/static/css/lecture.css
+++ b/src/main/resources/static/css/lecture.css
@@ -11,6 +11,7 @@
     border-radius: 8px;
     overflow-x: auto;
     font-family: 'Courier New', monospace;
+    color: #e2e8f0;
 }
 
 .code-block pre {

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -6,7 +6,7 @@
 <head>
     <meta charset="UTF-8">
     <title th:text="${lecture.title}">Lecture</title>
-    <link rel="stylesheet" th:href="@{/webjars/prismjs/1.29.0/themes/prism.min.css}">
+    <link rel="stylesheet" th:href="@{/webjars/prismjs/1.29.0/themes/prism-tomorrow.min.css}">
 </head>
 <body class="bg-light text-dark">
 


### PR DESCRIPTION
## Summary
- render lecture code blocks with light text color
- switch to Prism's dark "tomorrow" theme for syntax highlighting

## Testing
- `./gradlew build`
- `node -e "const {chromium}=require('@playwright/test');(async()=>{const b=await chromium.launch();const p=await b.newPage();await p.goto('file:///workspace/Giiku/src/main/resources/templates/index.html');console.log('Index title:',await p.title());await b.close();})();"`
- `node -e "const {chromium}=require('@playwright/test');const fs=require('fs');(async()=>{const b=await chromium.launch();const p=await b.newPage();await p.goto('file:///workspace/Giiku/src/main/resources/templates/lecture.html');const css=fs.readFileSync('src/main/resources/static/css/lecture.css','utf8');await p.addStyleTag({content:css});console.log('Code block color:',await p.$eval('.code-block',el=>getComputedStyle(el).color));await b.close();})();"`


------
https://chatgpt.com/codex/tasks/task_b_68ae775efdec8324a75928d246254089