### PR TITLE
Fetch lecture exercises from QuestionBank

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
@@ -31,6 +31,8 @@ import jp.co.apsa.giiku.domain.entity.LectureContentBlock;
 import jp.co.apsa.giiku.service.LectureService;
 import jp.co.apsa.giiku.service.MonthService;
 import jp.co.apsa.giiku.service.WeekService;
+import jp.co.apsa.giiku.service.QuestionBankService;
+import jp.co.apsa.giiku.domain.entity.QuestionBank;
 
 /**
  * 講義詳細ページを表示するコントローラー。
@@ -61,6 +63,8 @@ public class LectureViewController extends AbstractController {
     private LectureGoalService lectureGoalService;
     @Autowired
     private LectureContentBlockService lectureContentBlockService;
+    @Autowired
+    private QuestionBankService questionBankService;
 
     /**
      * 静的講義スライドを表示します。
@@ -114,8 +118,9 @@ public class LectureViewController extends AbstractController {
         }
         model.addAttribute("chapterContentBlocks", chapterContentBlocks);
 
-        // JSONフィールド（演習・追加リソース）をパース
-        model.addAttribute("exercises", parseJsonField(getExercisesJson(lecture), List.class));
+        // 演習問題と追加リソースを設定
+        List<QuestionBank> exercises = questionBankService.findByLectureIdOrderByQuestionNumber(lecture.getId());
+        model.addAttribute("exercises", exercises);
         model.addAttribute("additionalResources", parseJsonField(getAdditionalResourcesJson(lecture), List.class));
         
         // 前後の講義を取得
@@ -152,36 +157,6 @@ public class LectureViewController extends AbstractController {
             logger.warn("Failed to parse JSON field: " + jsonString, e);
             return null;
         }
-    }
-
-    /**
-     * 演習問題のJSONを取得（将来的にDBフィールドに追加予定）
-     */
-    private String getExercisesJson(Lecture lecture) {
-        // 現時点では固定値、将来的にはlecture.getExercises()など
-        return """
-            [
-                {
-                    "title": "Javaの特徴理解",
-                    "description": "以下の質問に答えてください：",
-                    "questions": [
-                        "Javaが「Write Once, Run Anywhere」と呼ばれる理由を、具体例を交えて説明してください。",
-                        "JDK、JRE、JVMの違いと役割を説明してください。",
-                        "なぜJavaでメモリ管理を意識する必要が少ないのか説明してください。"
-                    ],
-                    "answers": [
-                        {
-                            "question": "1. 「Write Once, Run Anywhere」の理由：",
-                            "answer": "Javaコードは一度コンパイルするとバイトコードという中間言語に変換され、JVM（Java仮想マシン）上で実行される。JVMが各OS（Windows、Mac、Linux）に対応しているため、同じバイトコードがどのプラットフォームでも動作する。"
-                        },
-                        {
-                            "question": "2. JDK、JRE、JVMの違い：",
-                            "answer": "<ul><li><strong>JVM</strong>：Javaプログラムを実行する仮想マシン</li><li><strong>JRE</strong>：Java実行環境（JVM + ライブラリ）</li><li><strong>JDK</strong>：Java開発キット（JRE + 開発ツール）</li></ul>"
-                        }
-                    ]
-                }
-            ]
-            """;
     }
 
     /**

--- a/src/main/java/jp/co/apsa/giiku/domain/repository/QuestionBankRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/QuestionBankRepository.java
@@ -51,6 +51,14 @@ public interface QuestionBankRepository extends JpaRepository<QuestionBank, Long
     List<QuestionBank> findByQuestionTextContainingIgnoreCaseAndIsActiveTrue(String text);
 
     /**
+     * 講義IDで検索し、問題番号の昇順で取得します。
+     *
+     * @param lectureId 講義ID
+     * @return 該当する問題一覧
+     */
+    List<QuestionBank> findByLectureIdOrderByQuestionNumber(Long lectureId);
+
+    /**
      * 難易度別の問題数を取得します。
      *
      * @return 難易度と件数の配列リスト

--- a/src/main/java/jp/co/apsa/giiku/service/QuestionBankService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/QuestionBankService.java
@@ -121,6 +121,14 @@ public class QuestionBankService {
     }
 
     @Transactional(readOnly = true)
+    public List<QuestionBank> findByLectureIdOrderByQuestionNumber(Long lectureId) {
+        if (lectureId == null) {
+            throw new IllegalArgumentException("講義IDは必須です");
+        }
+        return questionBankRepository.findByLectureIdOrderByQuestionNumber(lectureId);
+    }
+
+    @Transactional(readOnly = true)
     public long countAll() {
         return questionBankRepository.count();
     }

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -133,13 +133,8 @@
 
                 <div th:each="exercise, exStat : ${exercises}" class="border rounded p-4 mb-4">
                     <h3 class="fw-bold text-primary mb-3"
-                        th:text="${'演習問題' + (exStat.count) + ': ' + exercise.title}">演習問題タイトル</h3>
-                    <p class="mb-3" th:utext="${exercise.description}">問題説明</p>
-
-                    <ol th:if="${exercise.questions}" class="mb-4 ps-3">
-                        <li th:each="question, qStat : ${exercise.questions}"
-                            th:text="${(qStat.count) + '. ' + question}" class="mb-2">質問内容</li>
-                    </ol>
+                        th:text="${'演習問題' + exercise.questionNumber}">演習問題タイトル</h3>
+                    <p class="mb-3" th:utext="${exercise.questionText}">問題説明</p>
 
                     <button th:onclick="'toggleAnswer(\'answer' + ${exStat.count} + '\')'"
                             class="btn btn-primary">
@@ -150,16 +145,11 @@
                          th:id="'answer' + ${exStat.count}"
                          class="answer-content">
                         <h4 class="fw-semibold mb-2">回答例：</h4>
-                        <div class="d-flex flex-column gap-3 small">
-                            <div th:each="answer : ${exercise.answers}">
-                                <p class="fw-semibold" th:text="${answer.question}">質問</p>
-                                <p th:utext="${answer.answer}">回答</p>
-                            </div>
-                        </div>
+                        <p th:utext="${exercise.correctAnswer}">回答</p>
+                        <p th:if="${exercise.explanation}" th:utext="${exercise.explanation}">解説</p>
                     </div>
                 </div>
             </section>
-
             <!-- 追加リソース -->
             <section th:if="${additionalResources != null and !additionalResources.isEmpty()}" class="bg-white rounded shadow p-4 mb-4">
                 <h2 class="fw-bold text-primary mb-4">


### PR DESCRIPTION
## Summary
- add repository and service methods to load exercises ordered by question number
- serve exercises from database in lecture view controller
- render exercises from `QuestionBank` in lecture template

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_b_68ae8d47816c8324abb918380bddffc5