### PR TITLE
Add quiz question bank and lecture quiz section

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
@@ -28,9 +28,11 @@ import jp.co.apsa.giiku.service.LectureContentBlockService;
 import jp.co.apsa.giiku.domain.entity.LectureChapter;
 import jp.co.apsa.giiku.domain.entity.LectureGoal;
 import jp.co.apsa.giiku.domain.entity.LectureContentBlock;
+import jp.co.apsa.giiku.domain.entity.QuizQuestionBank;
 import jp.co.apsa.giiku.service.LectureService;
 import jp.co.apsa.giiku.service.MonthService;
 import jp.co.apsa.giiku.service.WeekService;
+import jp.co.apsa.giiku.service.QuizQuestionBankService;
 
 /**
  * 講義詳細ページを表示するコントローラー。
@@ -61,6 +63,8 @@ public class LectureViewController extends AbstractController {
     private LectureGoalService lectureGoalService;
     @Autowired
     private LectureContentBlockService lectureContentBlockService;
+    @Autowired
+    private QuizQuestionBankService quizQuestionBankService;
 
     /**
      * 静的講義スライドを表示します。
@@ -105,7 +109,7 @@ public class LectureViewController extends AbstractController {
         
         model.addAttribute("goals", goals);
         model.addAttribute("contentChapters", chapters);
-        
+
         // 各チャプターのコンテンツブロックを取得
         Map<Long, List<LectureContentBlock>> chapterContentBlocks = new HashMap<>();
         for (LectureChapter chapter : chapters) {
@@ -113,6 +117,10 @@ public class LectureViewController extends AbstractController {
             chapterContentBlocks.put(chapter.getId(), blocks);
         }
         model.addAttribute("chapterContentBlocks", chapterContentBlocks);
+
+        // 理解度テストのクイズ問題を取得
+        List<QuizQuestionBank> quizQuestions = quizQuestionBankService.findByLectureId(lecture.getId());
+        model.addAttribute("quizQuestions", quizQuestions);
 
         // JSONフィールド（演習・追加リソース）をパース
         model.addAttribute("exercises", parseJsonField(getExercisesJson(lecture), List.class));

--- a/src/main/java/jp/co/apsa/giiku/domain/entity/QuizQuestionBank.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/entity/QuizQuestionBank.java
@@ -1,0 +1,313 @@
+package jp.co.apsa.giiku.domain.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * クイズ問題バンクエンティティ
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
+@Entity
+@Table(name = "quiz_question_bank")
+public class QuizQuestionBank {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "lecture_id", nullable = false)
+    private Long lectureId;
+
+    @Column(name = "question_number", nullable = false)
+    private Integer questionNumber;
+
+    @Column(name = "question_type", nullable = false, length = 20)
+    private String questionType;
+
+    @Column(name = "question_text", nullable = false, columnDefinition = "TEXT")
+    private String questionText;
+
+    @Column(name = "option_a", columnDefinition = "TEXT")
+    private String optionA;
+
+    @Column(name = "option_b", columnDefinition = "TEXT")
+    private String optionB;
+
+    @Column(name = "option_c", columnDefinition = "TEXT")
+    private String optionC;
+
+    @Column(name = "option_d", columnDefinition = "TEXT")
+    private String optionD;
+
+    @Column(name = "option_e", columnDefinition = "TEXT")
+    private String optionE;
+
+    @Column(name = "option_f", columnDefinition = "TEXT")
+    private String optionF;
+
+    @Column(name = "correct_answer", nullable = false, columnDefinition = "TEXT")
+    private String correctAnswer;
+
+    @Column(name = "explanation", columnDefinition = "TEXT")
+    private String explanation;
+
+    @Column(name = "difficulty_level", length = 20)
+    private String difficultyLevel;
+
+    @Column(name = "time_limit")
+    private Integer timeLimit;
+
+    @Column(name = "points")
+    private Integer points;
+
+    @Column(name = "is_active")
+    private Boolean isActive = true;
+
+    @Column(name = "created_by")
+    private Long createdBy;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_by")
+    private Long updatedBy;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    /** デフォルトコンストラクタ */
+    public QuizQuestionBank() {
+    }
+
+    /** getId メソッド */
+    public Long getId() {
+        return id;
+    }
+
+    /** setId メソッド */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /** getLectureId メソッド */
+    public Long getLectureId() {
+        return lectureId;
+    }
+
+    /** setLectureId メソッド */
+    public void setLectureId(Long lectureId) {
+        this.lectureId = lectureId;
+    }
+
+    /** getQuestionNumber メソッド */
+    public Integer getQuestionNumber() {
+        return questionNumber;
+    }
+
+    /** setQuestionNumber メソッド */
+    public void setQuestionNumber(Integer questionNumber) {
+        this.questionNumber = questionNumber;
+    }
+
+    /** getQuestionType メソッド */
+    public String getQuestionType() {
+        return questionType;
+    }
+
+    /** setQuestionType メソッド */
+    public void setQuestionType(String questionType) {
+        this.questionType = questionType;
+    }
+
+    /** getQuestionText メソッド */
+    public String getQuestionText() {
+        return questionText;
+    }
+
+    /** setQuestionText メソッド */
+    public void setQuestionText(String questionText) {
+        this.questionText = questionText;
+    }
+
+    /** getOptionA メソッド */
+    public String getOptionA() {
+        return optionA;
+    }
+
+    /** setOptionA メソッド */
+    public void setOptionA(String optionA) {
+        this.optionA = optionA;
+    }
+
+    /** getOptionB メソッド */
+    public String getOptionB() {
+        return optionB;
+    }
+
+    /** setOptionB メソッド */
+    public void setOptionB(String optionB) {
+        this.optionB = optionB;
+    }
+
+    /** getOptionC メソッド */
+    public String getOptionC() {
+        return optionC;
+    }
+
+    /** setOptionC メソッド */
+    public void setOptionC(String optionC) {
+        this.optionC = optionC;
+    }
+
+    /** getOptionD メソッド */
+    public String getOptionD() {
+        return optionD;
+    }
+
+    /** setOptionD メソッド */
+    public void setOptionD(String optionD) {
+        this.optionD = optionD;
+    }
+
+    /** getOptionE メソッド */
+    public String getOptionE() {
+        return optionE;
+    }
+
+    /** setOptionE メソッド */
+    public void setOptionE(String optionE) {
+        this.optionE = optionE;
+    }
+
+    /** getOptionF メソッド */
+    public String getOptionF() {
+        return optionF;
+    }
+
+    /** setOptionF メソッド */
+    public void setOptionF(String optionF) {
+        this.optionF = optionF;
+    }
+
+    /** getCorrectAnswer メソッド */
+    public String getCorrectAnswer() {
+        return correctAnswer;
+    }
+
+    /** setCorrectAnswer メソッド */
+    public void setCorrectAnswer(String correctAnswer) {
+        this.correctAnswer = correctAnswer;
+    }
+
+    /** getExplanation メソッド */
+    public String getExplanation() {
+        return explanation;
+    }
+
+    /** setExplanation メソッド */
+    public void setExplanation(String explanation) {
+        this.explanation = explanation;
+    }
+
+    /** getDifficultyLevel メソッド */
+    public String getDifficultyLevel() {
+        return difficultyLevel;
+    }
+
+    /** setDifficultyLevel メソッド */
+    public void setDifficultyLevel(String difficultyLevel) {
+        this.difficultyLevel = difficultyLevel;
+    }
+
+    /** getTimeLimit メソッド */
+    public Integer getTimeLimit() {
+        return timeLimit;
+    }
+
+    /** setTimeLimit メソッド */
+    public void setTimeLimit(Integer timeLimit) {
+        this.timeLimit = timeLimit;
+    }
+
+    /** getPoints メソッド */
+    public Integer getPoints() {
+        return points;
+    }
+
+    /** setPoints メソッド */
+    public void setPoints(Integer points) {
+        this.points = points;
+    }
+
+    /** getIsActive メソッド */
+    public Boolean getIsActive() {
+        return isActive;
+    }
+
+    /** setIsActive メソッド */
+    public void setIsActive(Boolean active) {
+        isActive = active;
+    }
+
+    /** getCreatedBy メソッド */
+    public Long getCreatedBy() {
+        return createdBy;
+    }
+
+    /** setCreatedBy メソッド */
+    public void setCreatedBy(Long createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    /** getCreatedAt メソッド */
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    /** setCreatedAt メソッド */
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    /** getUpdatedBy メソッド */
+    public Long getUpdatedBy() {
+        return updatedBy;
+    }
+
+    /** setUpdatedBy メソッド */
+    public void setUpdatedBy(Long updatedBy) {
+        this.updatedBy = updatedBy;
+    }
+
+    /** getUpdatedAt メソッド */
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    /** setUpdatedAt メソッド */
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+        if (updatedAt == null) {
+            updatedAt = LocalDateTime.now();
+        }
+        if (isActive == null) {
+            isActive = true;
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/jp/co/apsa/giiku/domain/repository/QuizQuestionBankRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/QuizQuestionBankRepository.java
@@ -1,0 +1,25 @@
+package jp.co.apsa.giiku.domain.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import jp.co.apsa.giiku.domain.entity.QuizQuestionBank;
+
+/**
+ * QuizQuestionBank リポジトリインターフェース。
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
+@Repository
+public interface QuizQuestionBankRepository extends JpaRepository<QuizQuestionBank, Long> {
+
+    /**
+     * 指定された講義IDのクイズ問題を問題番号順に取得します。
+     *
+     * @param lectureId 講義ID
+     * @return クイズ問題一覧
+     */
+    List<QuizQuestionBank> findByLectureIdOrderByQuestionNumber(Long lectureId);
+}

--- a/src/main/java/jp/co/apsa/giiku/service/QuizQuestionBankService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/QuizQuestionBankService.java
@@ -1,0 +1,35 @@
+package jp.co.apsa.giiku.service;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import jp.co.apsa.giiku.domain.entity.QuizQuestionBank;
+import jp.co.apsa.giiku.domain.repository.QuizQuestionBankRepository;
+
+/**
+ * QuizQuestionBank サービスクラス。
+ * クイズ問題の取得機能を提供します。
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
+@Service
+@Transactional
+public class QuizQuestionBankService {
+
+    @Autowired
+    private QuizQuestionBankRepository quizQuestionBankRepository;
+
+    /**
+     * 指定された講義IDのクイズ問題を取得します。
+     *
+     * @param lectureId 講義ID
+     * @return クイズ問題一覧
+     */
+    @Transactional(readOnly = true)
+    public List<QuizQuestionBank> findByLectureId(Long lectureId) {
+        return quizQuestionBankRepository.findByLectureIdOrderByQuestionNumber(lectureId);
+    }
+}

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -125,6 +125,24 @@
                 </section>
             </div>
 
+            <!-- 理解度テストセクション -->
+            <section th:if="${quizQuestions != null and !quizQuestions.isEmpty()}" class="bg-white rounded shadow p-4 mb-4">
+                <h2 class="fw-bold text-primary mb-4">
+                    <i class="fas fa-question-circle me-2"></i>理解度テスト
+                </h2>
+                <div th:each="quiz : ${quizQuestions}" class="mb-4">
+                    <h3 class="fw-semibold mb-2" th:text="${quiz.questionNumber + '. ' + quiz.questionText}">問題文</h3>
+                    <ul class="list-unstyled ms-3">
+                        <li th:if="${quiz.optionA}" th:text="${'A. ' + quiz.optionA}">選択肢A</li>
+                        <li th:if="${quiz.optionB}" th:text="${'B. ' + quiz.optionB}">選択肢B</li>
+                        <li th:if="${quiz.optionC}" th:text="${'C. ' + quiz.optionC}">選択肢C</li>
+                        <li th:if="${quiz.optionD}" th:text="${'D. ' + quiz.optionD}">選択肢D</li>
+                        <li th:if="${quiz.optionE}" th:text="${'E. ' + quiz.optionE}">選択肢E</li>
+                        <li th:if="${quiz.optionF}" th:text="${'F. ' + quiz.optionF}">選択肢F</li>
+                    </ul>
+                </div>
+            </section>
+
             <!-- 演習問題セクション -->
             <section th:if="${exercises != null and !exercises.isEmpty()}" class="bg-white rounded shadow p-4 mb-4">
                 <h2 class="fw-bold text-primary mb-4">


### PR DESCRIPTION
## Summary
- add `QuizQuestionBank` entity with fields and mapping to `quiz_question_bank`
- create repository and service to fetch quiz questions per lecture
- load quiz questions in lecture view controller and display in new template section

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_b_68ae8ea629a483248e53f3aceb8031c8