### PR TITLE
feat: improve answer toggle

### DIFF
--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -229,8 +229,7 @@
         function showAnswer(answerId) {
             const answerElement = document.getElementById(answerId);
             if (answerElement) {
-                const isHidden = answerElement.style.display === 'none';
-                answerElement.style.display = isHidden ? 'block' : 'none';
+                const isShown = answerElement.classList.toggle('show');
 
                 // ボタンテキストを変更
                 const button = document.querySelector(`[onclick*="${answerId}"]`);
@@ -238,7 +237,7 @@
                     const icon = button.querySelector('i');
                     const label = button.querySelector('.answer-toggle-label');
                     if (icon && label) {
-                        if (isHidden) {
+                        if (isShown) {
                             icon.className = 'fas fa-eye-slash';
                             label.textContent = '回答を非表示';
                         } else {
@@ -253,8 +252,7 @@
         function toggleAnswer(answerId) {
             const answerElement = document.getElementById(answerId);
             if (answerElement) {
-                const isHidden = answerElement.style.display === 'none';
-                answerElement.style.display = isHidden ? 'block' : 'none';
+                const isShown = answerElement.classList.toggle('show');
 
                 // ボタンテキストを変更
                 const button = document.querySelector(`[onclick*="${answerId}"]`);
@@ -262,7 +260,7 @@
                     const icon = button.querySelector('i');
                     const label = button.querySelector('.answer-toggle-label');
                     if (icon && label) {
-                        if (isHidden) {
+                        if (isShown) {
                             icon.className = 'fas fa-eye-slash';
                             label.textContent = '回答例を非表示';
                         } else {


### PR DESCRIPTION
## Summary
- toggleAnswer/showAnswer 関数で `.answer-content.show` を利用した表示切替に変更
- ボタンのアイコンとラベルを表示状態に合わせて更新

## Testing
- `npm run test:e2e` *(psql が無いため失敗)*

------
https://chatgpt.com/codex/tasks/task_b_68aea01b1080832495b4ca909edac08d