### PR TITLE
演習問題回答ボタンの権限制御追加

### DIFF
--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -167,7 +167,8 @@
                         th:text="${'演習問題' + exercise.questionNumber}">演習問題タイトル</h3>
                     <p class="mb-3" th:utext="${exercise.questionText}">問題説明</p>
 
-                    <button th:onclick="'toggleAnswer(\'answer' + ${exStat.count} + '\')'"
+                    <button sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')"
+                            th:onclick="'toggleAnswer(\'answer' + ${exStat.count} + '\')'"
                             class="btn btn-primary d-flex align-items-center gap-2">
                         <i class="fas fa-eye"></i>
                         <span class="answer-toggle-label">回答例を表示</span>


### PR DESCRIPTION
## Summary
- 演習問題の回答表示ボタンを講師権限ユーザーのみに限定

## Testing
- `xdg-open src/main/resources/templates/index.html` (no method available)


------
https://chatgpt.com/codex/tasks/task_b_68aea32e34fc83248e73b5f5de75591f