### PR TITLE
fix: remove numeric prefixes from quiz options

### DIFF
--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -133,12 +133,12 @@
                 <div th:each="quiz, quizStat : ${quizQuestions}" class="mb-4">
                     <h3 class="fw-semibold mb-2" th:text="${quiz.questionNumber + '. ' + quiz.questionText}">問題文</h3>
                     <ol class="quiz-options ms-3">
-                        <li th:if="${quiz.optionA}" th:text="${quiz.optionA}">選択肢A</li>
-                        <li th:if="${quiz.optionB}" th:text="${quiz.optionB}">選択肢B</li>
-                        <li th:if="${quiz.optionC}" th:text="${quiz.optionC}">選択肢C</li>
-                        <li th:if="${quiz.optionD}" th:text="${quiz.optionD}">選択肢D</li>
-                        <li th:if="${quiz.optionE}" th:text="${quiz.optionE}">選択肢E</li>
-                        <li th:if="${quiz.optionF}" th:text="${quiz.optionF}">選択肢F</li>
+                        <li th:if="${quiz.optionA}" th:text="${#strings.substringAfter(quiz.optionA, '. ')}">選択肢A</li>
+                        <li th:if="${quiz.optionB}" th:text="${#strings.substringAfter(quiz.optionB, '. ')}">選択肢B</li>
+                        <li th:if="${quiz.optionC}" th:text="${#strings.substringAfter(quiz.optionC, '. ')}">選択肢C</li>
+                        <li th:if="${quiz.optionD}" th:text="${#strings.substringAfter(quiz.optionD, '. ')}">選択肢D</li>
+                        <li th:if="${quiz.optionE}" th:text="${#strings.substringAfter(quiz.optionE, '. ')}">選択肢E</li>
+                        <li th:if="${quiz.optionF}" th:text="${#strings.substringAfter(quiz.optionF, '. ')}">選択肢F</li>
                     </ol>
                     <div sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')">
                         <button th:onclick="'showAnswer(\'answer' + ${quizStat.count} + '\')'"


### PR DESCRIPTION
## Summary
- remove numeric prefixes from quiz options by using `#strings.substringAfter`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68aeafce74548324838874041d432376