### PR TITLE
クイズ正解表示を赤字で統合

### DIFF
--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -148,8 +148,7 @@
                         </button>
                         <div th:id="'answer' + ${quizStat.count}"
                              class="answer-content">
-                            <h4 class="fw-semibold mb-2">正解：</h4>
-                            <p th:text="${quiz.correctAnswer}">正解</p>
+                            <h4 class="fw-semibold mb-2">正解：<span class="text-danger" th:text="${quiz.correctAnswer}">1</span></h4>
                             <p th:if="${quiz.explanation}" th:utext="${quiz.explanation}">解説</p>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- クイズの正解表示を1行に統合し、正解番号を赤字で表示

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68aeb1efb62c8324965af8f7ffda4ea5