### PR TITLE
feat: display quiz explanation in lecture view

### DIFF
--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -149,7 +149,10 @@
                         <div th:id="'answer' + ${quizStat.count}"
                              class="answer-content">
                             <h4 class="fw-semibold mb-2">正解：<span class="text-danger" th:text="${quiz.correctAnswer}">1</span></h4>
-                            <p th:if="${quiz.explanation}" th:utext="${quiz.explanation}">解説</p>
+                            <div th:if="${quiz.explanation}">
+                                <h5 class="fw-semibold">解説：</h5>
+                                <p th:utext="${quiz.explanation}">解説文</p>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- show quiz explanations in lecture page when present
- confirm quiz_question_bank schema includes explanation column and data

## Testing
- `sudo -u postgres psql -d giiku_db -c "SELECT id, explanation FROM quiz_question_bank;"`
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_b_68aeb7e9eeec8324b29796c269987702