### PR TITLE
Remove quiz explanation header

### DIFF
--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -149,10 +149,7 @@
                         <div th:id="'answer' + ${quizStat.count}"
                              class="answer-content">
                             <h4 class="fw-semibold mb-2">正解：<span class="text-danger" th:text="${quiz.correctAnswer}">1</span></h4>
-                            <div th:if="${quiz.explanation}">
-                                <h5 class="fw-semibold">解説：</h5>
-                                <p th:utext="${quiz.explanation}">解説文</p>
-                            </div>
+                            <p th:if="${quiz.explanation}" class="mt-0" th:utext="${quiz.explanation}">解説文</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Show quiz explanations directly under correct answers with minimal spacing

## Testing
- `./gradlew test`
- `npm run test:e2e` *(fails: connection to Postgres refused)*
- `npx playwright open src/main/resources/templates/lecture.html` *(fails: requires X server; page loaded headlessly with Playwright script instead)*
- `node - <<'NODE' ...` *(Playwright headless load of lecture.html successful)*

------
https://chatgpt.com/codex/tasks/task_b_68aebb4fc4208324bca93efd2045b554