### PR TITLE
Refactor chapters schema

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/domain/entity/LectureContentBlock.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/entity/LectureContentBlock.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
- * 講義コンテンツブロックエンティティ
+ * チャプターコンテンツブロックエンティティ
  * チャプター内の個別コンテンツを保持する。
  *
  * @author 株式会社アプサ
@@ -14,7 +14,7 @@ import lombok.EqualsAndHashCode;
  * @since 2025
  */
 @Entity
-@Table(name = "lecture_content_blocks")
+@Table(name = "chapter_content_blocks")
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class LectureContentBlock extends AuditableEntity {

--- a/src/main/resources/db/migration/V000__Create_Users_And_Companies.sql
+++ b/src/main/resources/db/migration/V000__Create_Users_And_Companies.sql
@@ -268,10 +268,9 @@ COMMENT ON COLUMN lectures.updated_at IS '更新日時（レコード更新時�
 COMMENT ON COLUMN lectures.version IS 'バージョン（楽観ロック用）';
 COMMENT ON COLUMN lectures.updated_by IS '更新者（レコード更新したユーザーID）';
 
--- Lecture chapters table
-CREATE TABLE lecture_chapters (
+-- Chapters table
+CREATE TABLE chapters (
     id BIGSERIAL PRIMARY KEY,
-    lecture_id BIGINT NOT NULL REFERENCES lectures(id),
     chapter_number INTEGER NOT NULL,
     title VARCHAR(200) NOT NULL,
     description TEXT,
@@ -285,18 +284,37 @@ CREATE TABLE lecture_chapters (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
-COMMENT ON COLUMN lecture_chapters.lecture_id IS '講義ID（lectures.id）';
-COMMENT ON COLUMN lecture_chapters.chapter_number IS 'チャプター番号';
-COMMENT ON COLUMN lecture_chapters.title IS 'チャプタータイトル';
-COMMENT ON COLUMN lecture_chapters.description IS 'チャプター説明';
-COMMENT ON COLUMN lecture_chapters.duration_minutes IS 'チャプター想定時間（分）';
-COMMENT ON COLUMN lecture_chapters.sort_order IS '並び順';
-COMMENT ON COLUMN lecture_chapters.is_active IS '有効状態（チャプターの使用可否）';
-COMMENT ON COLUMN lecture_chapters.version IS 'バージョン（楽観ロック用）';
-COMMENT ON COLUMN lecture_chapters.created_by IS '作成者（レコード作成したユーザーID）';
-COMMENT ON COLUMN lecture_chapters.created_at IS '作成日時（レコード作成時刻）';
-COMMENT ON COLUMN lecture_chapters.updated_by IS '更新者（レコード更新したユーザーID）';
-COMMENT ON COLUMN lecture_chapters.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN chapters.chapter_number IS 'チャプター番号';
+COMMENT ON COLUMN chapters.title IS 'チャプタータイトル';
+COMMENT ON COLUMN chapters.description IS 'チャプター説明';
+COMMENT ON COLUMN chapters.duration_minutes IS 'チャプター想定時間（分）';
+COMMENT ON COLUMN chapters.sort_order IS '並び順';
+COMMENT ON COLUMN chapters.is_active IS '有効状態（チャプターの使用可否）';
+COMMENT ON COLUMN chapters.version IS 'バージョン（楽観ロック用）';
+COMMENT ON COLUMN chapters.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN chapters.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN chapters.updated_by IS '更新者（レコード更新したユーザーID）';
+COMMENT ON COLUMN chapters.updated_at IS '更新日時（レコード更新時刻）';
+
+-- Lecture and chapter relationship table
+CREATE TABLE lecture_chapter_links (
+    id BIGSERIAL PRIMARY KEY,
+    lecture_id BIGINT NOT NULL REFERENCES lectures(id),
+    chapter_id BIGINT NOT NULL REFERENCES chapters(id),
+    sort_order INTEGER,
+    created_by BIGINT REFERENCES users(id),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_by BIGINT REFERENCES users(id),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON COLUMN lecture_chapter_links.lecture_id IS '講義ID（lectures.id）';
+COMMENT ON COLUMN lecture_chapter_links.chapter_id IS 'チャプターID（chapters.id）';
+COMMENT ON COLUMN lecture_chapter_links.sort_order IS '並び順';
+COMMENT ON COLUMN lecture_chapter_links.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN lecture_chapter_links.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN lecture_chapter_links.updated_by IS '更新者（レコード更新したユーザーID）';
+COMMENT ON COLUMN lecture_chapter_links.updated_at IS '更新日時（レコード更新時刻）';
 
 -- Lecture goals table
 CREATE TABLE lecture_goals (
@@ -320,10 +338,10 @@ COMMENT ON COLUMN lecture_goals.created_at IS '作成日時（レコード作成
 COMMENT ON COLUMN lecture_goals.updated_by IS '更新者（レコード更新したユーザーID）';
 COMMENT ON COLUMN lecture_goals.updated_at IS '更新日時（レコード更新時刻）';
 
--- Lecture content blocks table
-CREATE TABLE lecture_content_blocks (
+-- Chapter content blocks table
+CREATE TABLE chapter_content_blocks (
     id BIGSERIAL PRIMARY KEY,
-    chapter_id BIGINT NOT NULL REFERENCES lecture_chapters(id),
+    chapter_id BIGINT NOT NULL REFERENCES chapters(id),
     block_type VARCHAR(50) NOT NULL,
     title VARCHAR(200) NOT NULL,
     content TEXT,
@@ -335,25 +353,26 @@ CREATE TABLE lecture_content_blocks (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
-COMMENT ON COLUMN lecture_content_blocks.chapter_id IS 'チャプターID（lecture_chapters.id）';
-COMMENT ON COLUMN lecture_content_blocks.block_type IS 'ブロック種別';
-COMMENT ON COLUMN lecture_content_blocks.title IS 'ブロックタイトル';
-COMMENT ON COLUMN lecture_content_blocks.content IS 'ブロック内容';
-COMMENT ON COLUMN lecture_content_blocks.sort_order IS '並び順';
-COMMENT ON COLUMN lecture_content_blocks.version IS 'バージョン（楽観ロック用）';
-COMMENT ON COLUMN lecture_content_blocks.created_by IS '作成者（レコード作成したユーザーID）';
-COMMENT ON COLUMN lecture_content_blocks.created_at IS '作成日時（レコード作成時刻）';
-COMMENT ON COLUMN lecture_content_blocks.updated_by IS '更新者（レコード更新したユーザーID）';
-COMMENT ON COLUMN lecture_content_blocks.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN chapter_content_blocks.chapter_id IS 'チャプターID（chapters.id）';
+COMMENT ON COLUMN chapter_content_blocks.block_type IS 'ブロック種別';
+COMMENT ON COLUMN chapter_content_blocks.title IS 'ブロックタイトル';
+COMMENT ON COLUMN chapter_content_blocks.content IS 'ブロック内容';
+COMMENT ON COLUMN chapter_content_blocks.sort_order IS '並び順';
+COMMENT ON COLUMN chapter_content_blocks.version IS 'バージョン（楽観ロック用）';
+COMMENT ON COLUMN chapter_content_blocks.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN chapter_content_blocks.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN chapter_content_blocks.updated_by IS '更新者（レコード更新したユーザーID）';
+COMMENT ON COLUMN chapter_content_blocks.updated_at IS '更新日時（レコード更新時刻）';
 
 -- Performance indexes
 CREATE INDEX idx_weeks_month ON weeks(month_id);
 CREATE INDEX idx_days_week ON days(week_id);
 CREATE INDEX idx_lectures_day ON lectures(day_id);
 CREATE INDEX idx_lectures_active ON lectures(is_active);
-CREATE INDEX idx_lecture_chapters_lecture ON lecture_chapters(lecture_id);
 CREATE INDEX idx_lecture_goals_lecture ON lecture_goals(lecture_id);
-CREATE INDEX idx_content_blocks_chapter ON lecture_content_blocks(chapter_id);
+CREATE INDEX idx_content_blocks_chapter ON chapter_content_blocks(chapter_id);
+CREATE INDEX idx_lecture_chapter_links_lecture ON lecture_chapter_links(lecture_id);
+CREATE INDEX idx_lecture_chapter_links_chapter ON lecture_chapter_links(chapter_id);
 
 -- Unique constraints
 ALTER TABLE weeks ADD CONSTRAINT unique_week_per_month UNIQUE(month_id, week_number);
@@ -364,9 +383,10 @@ COMMENT ON TABLE months IS '月テーブル（3ヶ月のカリキュラム月を
 COMMENT ON TABLE weeks IS '週テーブル（18週のカリキュラム週を管理）';
 COMMENT ON TABLE days IS '日テーブル（54日のカリキュラム日を管理）';
 COMMENT ON TABLE lectures IS '講義テーブル（講義の基本情報を管理）';
-COMMENT ON TABLE lecture_chapters IS '講義チャプターテーブル（講義内の章情報を管理）';
+COMMENT ON TABLE chapters IS 'チャプターテーブル（章情報を管理）';
+COMMENT ON TABLE lecture_chapter_links IS '講義チャプター関連テーブル（講義とチャプターの紐付け）';
 COMMENT ON TABLE lecture_goals IS '講義目標テーブル（講義の学習目標を管理）';
-COMMENT ON TABLE lecture_content_blocks IS '講義コンテンツブロックテーブル（チャプター内のコンテンツを管理）';
+COMMENT ON TABLE chapter_content_blocks IS 'チャプターコンテンツブロックテーブル（チャプター内のコンテンツを管理）';
 -- V002: Create Training Management Tables
 -- Creates training programs, schedules, assignments, and user role extensions
 -- Supports instructor and student management with course copying functionality
@@ -912,10 +932,10 @@ ALTER TABLE mock_test_results
 -- Creates comprehensive question bank, submission tracking, and grade management
 -- Supports exercises, quizzes, and mock tests with detailed scoring
 
--- Exercise Question Bank (20+ questions per lecture)
+-- Exercise Question Bank (20+ questions per chapter)
 CREATE TABLE exercise_question_bank (
     id BIGSERIAL PRIMARY KEY,
-    lecture_id BIGINT NOT NULL REFERENCES lectures(id),
+    chapter_id BIGINT NOT NULL REFERENCES chapters(id),
     question_number INTEGER NOT NULL,
     question_type VARCHAR(20) DEFAULT 'multiple_choice' NOT NULL CHECK (question_type IN ('multiple_choice', 'essay', 'code', 'fill_blank')),
     question_text TEXT NOT NULL,
@@ -931,7 +951,8 @@ CREATE TABLE exercise_question_bank (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
-COMMENT ON COLUMN exercise_question_bank.question_number IS '問題番号（講義内での順序）';
+COMMENT ON COLUMN exercise_question_bank.chapter_id IS 'チャプターID（chapters.id）';
+COMMENT ON COLUMN exercise_question_bank.question_number IS '問題番号（チャプター内での順序）';
 COMMENT ON COLUMN exercise_question_bank.question_text IS '問題文（演習問題の内容）';
 COMMENT ON COLUMN exercise_question_bank.question_options IS '選択肢（多択問題の場合）';
 COMMENT ON COLUMN exercise_question_bank.correct_answer IS '正解（多択・穴埋め問題の正答）';
@@ -950,7 +971,7 @@ CREATE TABLE quiz (
     title VARCHAR(200) NOT NULL,
     description TEXT,
     training_program_id BIGINT REFERENCES training_programs(id),
-    lecture_id BIGINT REFERENCES lectures(id),
+    chapter_id BIGINT REFERENCES chapters(id),
     student_id BIGINT NOT NULL REFERENCES users(id),
     instructor_id BIGINT REFERENCES instructors(id),
     company_id BIGINT REFERENCES companies(id),
@@ -980,7 +1001,7 @@ COMMENT ON TABLE quiz IS 'クイズ実施情報';
 COMMENT ON COLUMN quiz.title IS 'タイトル';
 COMMENT ON COLUMN quiz.description IS '説明';
 COMMENT ON COLUMN quiz.training_program_id IS '研修プログラムID';
-COMMENT ON COLUMN quiz.lecture_id IS '講義ID';
+COMMENT ON COLUMN quiz.chapter_id IS 'チャプターID';
 COMMENT ON COLUMN quiz.student_id IS '受講者ID';
 COMMENT ON COLUMN quiz.instructor_id IS '講師ID';
 COMMENT ON COLUMN quiz.company_id IS '会社ID';
@@ -1005,10 +1026,10 @@ COMMENT ON COLUMN quiz.is_active IS '有効状態';
 COMMENT ON COLUMN quiz.created_at IS '作成日時';
 COMMENT ON COLUMN quiz.updated_at IS '更新日時';
 
--- Quiz Question Bank (per lecture)
+-- Quiz Question Bank (per chapter)
 CREATE TABLE quiz_question_bank (
     id BIGSERIAL PRIMARY KEY,
-    lecture_id BIGINT NOT NULL REFERENCES lectures(id),
+    chapter_id BIGINT NOT NULL REFERENCES chapters(id),
     question_number INTEGER NOT NULL,
     question_type VARCHAR(20) DEFAULT 'multiple_choice' NOT NULL CHECK (question_type IN ('multiple_choice', 'true_false', 'short_answer')),
     question_text TEXT NOT NULL,
@@ -1030,7 +1051,8 @@ CREATE TABLE quiz_question_bank (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
-COMMENT ON COLUMN quiz_question_bank.question_number IS '問題番号（講義内での順序）';
+COMMENT ON COLUMN quiz_question_bank.chapter_id IS 'チャプターID（chapters.id）';
+COMMENT ON COLUMN quiz_question_bank.question_number IS '問題番号（チャプター内での順序）';
 COMMENT ON COLUMN quiz_question_bank.question_text IS '問題文（クイズ問題の内容）';
 COMMENT ON COLUMN quiz_question_bank.option_a IS '選択肢A';
 COMMENT ON COLUMN quiz_question_bank.option_b IS '選択肢B';
@@ -1110,7 +1132,7 @@ COMMENT ON COLUMN mock_test_questions.updated_by IS '更新者（レコード更
 CREATE TABLE exercise_submissions (
     id BIGSERIAL PRIMARY KEY,
     training_assignment_id BIGINT NOT NULL REFERENCES training_assignments(id),
-    lecture_id BIGINT NOT NULL REFERENCES lectures(id),
+    chapter_id BIGINT NOT NULL REFERENCES chapters(id),
     question_id BIGINT NOT NULL REFERENCES exercise_question_bank(id),
     student_answer TEXT,
     is_correct BOOLEAN,
@@ -1141,7 +1163,7 @@ COMMENT ON COLUMN exercise_submissions.updated_at IS '更新日時（レコー�
 CREATE TABLE quiz_submissions (
     id BIGSERIAL PRIMARY KEY,
     training_assignment_id BIGINT NOT NULL REFERENCES training_assignments(id),
-    lecture_id BIGINT NOT NULL REFERENCES lectures(id),
+    chapter_id BIGINT NOT NULL REFERENCES chapters(id),
     question_id BIGINT NOT NULL REFERENCES quiz_question_bank(id),
     student_answer TEXT NOT NULL,
     is_correct BOOLEAN NOT NULL,
@@ -1313,15 +1335,16 @@ COMMENT ON COLUMN grade_settings.updated_at IS '更新日時（レコード更�
 COMMENT ON COLUMN grade_settings.updated_by IS '更新者（レコード更新したユーザーID）';
 
 -- Performance Indexes for optimization
-CREATE INDEX idx_exercise_questions_lecture ON exercise_question_bank(lecture_id);
+CREATE INDEX idx_exercise_questions_chapter ON exercise_question_bank(chapter_id);
 CREATE INDEX idx_exercise_questions_active ON exercise_question_bank(is_active);
-CREATE INDEX idx_quiz_questions_lecture ON quiz_question_bank(lecture_id);
+CREATE INDEX idx_quiz_chapter ON quiz(chapter_id);
+CREATE INDEX idx_quiz_questions_chapter ON quiz_question_bank(chapter_id);
 CREATE INDEX idx_quiz_questions_active ON quiz_question_bank(is_active);
 CREATE INDEX idx_mock_test_active ON mock_test_bank(is_active);
 CREATE INDEX idx_exercise_submissions_assignment ON exercise_submissions(training_assignment_id);
-CREATE INDEX idx_exercise_submissions_lecture ON exercise_submissions(lecture_id);
+CREATE INDEX idx_exercise_submissions_chapter ON exercise_submissions(chapter_id);
 CREATE INDEX idx_quiz_submissions_assignment ON quiz_submissions(training_assignment_id);
-CREATE INDEX idx_quiz_submissions_lecture ON quiz_submissions(lecture_id);
+CREATE INDEX idx_quiz_submissions_chapter ON quiz_submissions(chapter_id);
 CREATE INDEX idx_mock_submissions_assignment ON mock_test_submissions(training_assignment_id);
 CREATE INDEX idx_lecture_grades_assignment ON lecture_grades(training_assignment_id);
 CREATE INDEX idx_lecture_grades_lecture ON lecture_grades(lecture_id);
@@ -1330,9 +1353,9 @@ CREATE INDEX idx_student_summaries_lecture ON student_grade_summaries(lecture_id
 
 -- Unique constraints for data integrity
 ALTER TABLE exercise_question_bank ADD CONSTRAINT unique_exercise_question_order
-    UNIQUE(lecture_id, question_number);
+    UNIQUE(chapter_id, question_number);
 ALTER TABLE quiz_question_bank ADD CONSTRAINT unique_quiz_question_order
-    UNIQUE(lecture_id, question_number);
+    UNIQUE(chapter_id, question_number);
 ALTER TABLE mock_test_questions ADD CONSTRAINT unique_mock_question_order 
     UNIQUE(mock_test_id, question_order);
 ALTER TABLE lecture_grades ADD CONSTRAINT unique_lecture_assignment_grade
@@ -1345,8 +1368,8 @@ ALTER TABLE grade_settings ADD CONSTRAINT check_weights_sum
     CHECK (exercise_weight + quiz_weight + mock_test_weight = 1.0);
 
 -- Comments on tables
-COMMENT ON TABLE exercise_question_bank IS '演習問題バンク（各講義の演習問題を管理）';
-COMMENT ON TABLE quiz_question_bank IS 'クイズ問題バンク（各講義のクイズ問題を管理）';
+COMMENT ON TABLE exercise_question_bank IS '演習問題バンク（各チャプターの演習問題を管理）';
+COMMENT ON TABLE quiz_question_bank IS 'クイズ問題バンク（各チャプターのクイズ問題を管理）';
 COMMENT ON TABLE mock_test_bank IS '模擬試験バンク（模擬試験の定義を管理）';
 COMMENT ON TABLE mock_test_questions IS '模擬試験問題（模擬試験の個別問題を管理）';
 COMMENT ON TABLE exercise_submissions IS '演習提出（学生の演習問題解答を管理）';

--- a/src/main/resources/db/migration/V004__Insert_Java_Lecture_Data.sql
+++ b/src/main/resources/db/migration/V004__Insert_Java_Lecture_Data.sql
@@ -29,7 +29,7 @@ INSERT INTO lecture_goals (id, lecture_id, goal_description, sort_order, created
 (6, 1, 'コメントの種類と書き方を理解し、保守性の高いコードを書くことができる', 6, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP),
 (7, 1, 'コンパイルから実行までの流れを理解し、エラーの原因を特定できる', 7, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP);
 -- 講義1-1のコンテンツブロック投入
-INSERT INTO lecture_content_blocks (id, chapter_id, block_type, title, content, sort_order, created_by, created_at, updated_by, updated_at) VALUES
+INSERT INTO chapter_content_blocks (id, chapter_id, block_type, title, content, sort_order, created_by, created_at, updated_by, updated_at) VALUES
 (1, 1, 'OVERVIEW', '概要', 'Java言語は1995年にSun Microsystems（現Oracle）によって開発されたオブジェクト指向プログラミング言語です。「Write Once, Run Anywhere」の理念のもと、プラットフォーム独立性を実現し、現在では企業システム開発からモバイルアプリケーション開発まで幅広く使用されています。', 1, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP),
 (2, 1, 'DETAIL', 'Javaの歴史と発展', 'Java言語は以下のような発展を遂げてきました：
 
@@ -98,7 +98,7 @@ Javaは純粋なオブジェクト指向言語で、すべてのコードはク�
 ガベージコレクションにより、不要になったオブジェクトのメモリが自動的に解放されます。', 5, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP);
 
 -- 講義1-2のコンテンツブロック投入
-INSERT INTO lecture_content_blocks (id, chapter_id, block_type, title, content, sort_order, created_by, created_at, updated_by, updated_at) VALUES
+INSERT INTO chapter_content_blocks (id, chapter_id, block_type, title, content, sort_order, created_by, created_at, updated_by, updated_at) VALUES
 (6, 2, 'OVERVIEW', '概要', 'Javaの主要な特徴と利点を詳しく学習します。プラットフォーム独立性、オブジェクト指向、メモリ管理、セキュリティ、豊富なライブラリなど、Javaが企業システム開発で選ばれる理由を理解します。', 1, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP),
 (7, 2, 'DETAIL', 'Write Once, Run Anywhere（WORA）', 'Javaの最大の特徴の一つは、プラットフォーム独立性です：
 
@@ -240,7 +240,7 @@ INSERT INTO lecture_goals (id, lecture_id, goal_description, sort_order, created
 (13, 2, 'バージョン管理システムを使用してソースコードを管理できる', 6, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP);
 
 -- 講義2-1のコンテンツブロック投入（JDKのインストール）
-INSERT INTO lecture_content_blocks (id, chapter_id, block_type, title, content, sort_order, created_by, created_at, updated_by, updated_at) VALUES
+INSERT INTO chapter_content_blocks (id, chapter_id, block_type, title, content, sort_order, created_by, created_at, updated_by, updated_at) VALUES
 (11, 9, 'OVERVIEW', '概要', 'Java開発を始めるために最も重要なのがJDK（Java Development Kit）のインストールです。JDKにはJavaコンパイラ（javac）、Java実行環境（JRE）、開発ツール群が含まれています。Oracle JDKとOpenJDKの違いを理解し、開発目的に応じた適切な選択を行います。', 1, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP),
 (12, 9, 'DETAIL', 'JDKの種類と選択', '■ Oracle JDK vs OpenJDK
 【Oracle JDK】
@@ -333,7 +333,7 @@ echo $PATH
 ```', 5, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP);
 
 -- 講義2-2のコンテンツブロック投入（IDEの選択と設定）
-INSERT INTO lecture_content_blocks (id, chapter_id, block_type, title, content, sort_order, created_by, created_at, updated_by, updated_at) VALUES
+INSERT INTO chapter_content_blocks (id, chapter_id, block_type, title, content, sort_order, created_by, created_at, updated_by, updated_at) VALUES
 (16, 10, 'OVERVIEW', '概要', 'IDE（統合開発環境）は、Java開発の生産性を大幅に向上させるツールです。主要なJava IDE（IntelliJ IDEA、Eclipse、Visual Studio Code）の特徴を比較し、用途に応じた選択方法を学習します。その後、選択したIDEの基本設定とプラグイン導入を実践的に行います。', 1, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP),
 (17, 10, 'DETAIL', '主要Java IDEの比較', '■ IntelliJ IDEA
 【特徴】
@@ -473,7 +473,7 @@ INSERT INTO lecture_goals (id, lecture_id, goal_description, sort_order, created
 (19, 3, '名前空間の衝突を理解し、適切に回避する方法を知っている', 6, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP);
 
 -- 講義3-1のコンテンツブロック投入（パッケージの概念）
-INSERT INTO lecture_content_blocks (id, chapter_id, block_type, title, content, sort_order, created_by, created_at, updated_by, updated_at) VALUES
+INSERT INTO chapter_content_blocks (id, chapter_id, block_type, title, content, sort_order, created_by, created_at, updated_by, updated_at) VALUES
 (20, 16, 'OVERVIEW', '概要', 'パッケージはJavaにおける名前空間（namespace）の仕組みです。関連するクラスやインターフェースをグループ化し、名前の衝突を避け、コードの整理と再利用を促進します。大規模なソフトウェア開発には不可欠な概念を基礎から理解します。', 1, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP),
 (21, 16, 'DETAIL', 'パッケージの必要性', '■ 名前の衝突回避
 異なる開発者や組織が同じクラス名を使用する場合の問題：
@@ -679,7 +679,7 @@ com.company.project
 - リファクタリング時のパッケージ移動に注意', 6, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP);
 
 -- 講義3-2のコンテンツブロック投入（パッケージの作成）
-INSERT INTO lecture_content_blocks (id, chapter_id, block_type, title, content, sort_order, created_by, created_at, updated_by, updated_at) VALUES
+INSERT INTO chapter_content_blocks (id, chapter_id, block_type, title, content, sort_order, created_by, created_at, updated_by, updated_at) VALUES
 (26, 17, 'OVERVIEW', '概要', 'package文を使用して実際にパッケージを作成する方法を学習します。ディレクトリ構造の作成から、package文の記述、コンパイルと実行までの一連の流れを実践的に理解します。', 1, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP),
 (27, 17, 'CODE', 'パッケージ作成の実践例', '■ ディレクトリ構造の作成
 ```bash
@@ -848,7 +848,7 @@ package com.mycompany.helper;  // エラー
 - 他のパッケージからインポートできない制限あり', 4, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP);
 
 -- 講義3-3のコンテンツブロック投入（importステートメント）
-INSERT INTO lecture_content_blocks (id, chapter_id, block_type, title, content, sort_order, created_by, created_at, updated_by, updated_at) VALUES
+INSERT INTO chapter_content_blocks (id, chapter_id, block_type, title, content, sort_order, created_by, created_at, updated_by, updated_at) VALUES
 (30, 18, 'OVERVIEW', '概要', 'import文を使用して他のパッケージのクラスを利用する方法を学習します。単一クラスのインポート、パッケージ全体のインポート、静的インポートの使い方と、それぞれの適切な使用場面を理解します。', 1, 1, CURRENT_TIMESTAMP, 1, CURRENT_TIMESTAMP),
 (31, 18, 'CODE', 'import文の基本的な使い方', '■ 単一クラスのインポート（推奨）
 ```java
@@ -1049,6 +1049,6 @@ INSERT INTO lectures (day_id, lecture_number, title, description, goals, content
 
 SELECT setval('lecture_chapters_id_seq',   (SELECT MAX(id) FROM lecture_chapters));
 SELECT setval('lecture_goals_id_seq',      (SELECT MAX(id) FROM lecture_goals));
-SELECT setval('lecture_content_blocks_id_seq', (SELECT MAX(id) FROM lecture_content_blocks));
+SELECT setval('chapter_content_blocks_id_seq', (SELECT MAX(id) FROM chapter_content_blocks));
 
 COMMIT;

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -268,10 +268,9 @@ COMMENT ON COLUMN lectures.updated_at IS '更新日時（レコード更新時�
 COMMENT ON COLUMN lectures.version IS 'バージョン（楽観ロック用）';
 COMMENT ON COLUMN lectures.updated_by IS '更新者（レコード更新したユーザーID）';
 
--- Lecture chapters table
-CREATE TABLE lecture_chapters (
+-- Chapters table
+CREATE TABLE chapters (
     id BIGSERIAL PRIMARY KEY,
-    lecture_id BIGINT NOT NULL REFERENCES lectures(id),
     chapter_number INTEGER NOT NULL,
     title VARCHAR(200) NOT NULL,
     description TEXT,
@@ -285,18 +284,37 @@ CREATE TABLE lecture_chapters (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
-COMMENT ON COLUMN lecture_chapters.lecture_id IS '講義ID（lectures.id）';
-COMMENT ON COLUMN lecture_chapters.chapter_number IS 'チャプター番号';
-COMMENT ON COLUMN lecture_chapters.title IS 'チャプタータイトル';
-COMMENT ON COLUMN lecture_chapters.description IS 'チャプター説明';
-COMMENT ON COLUMN lecture_chapters.duration_minutes IS 'チャプター想定時間（分）';
-COMMENT ON COLUMN lecture_chapters.sort_order IS '並び順';
-COMMENT ON COLUMN lecture_chapters.is_active IS '有効状態（チャプターの使用可否）';
-COMMENT ON COLUMN lecture_chapters.version IS 'バージョン（楽観ロック用）';
-COMMENT ON COLUMN lecture_chapters.created_by IS '作成者（レコード作成したユーザーID）';
-COMMENT ON COLUMN lecture_chapters.created_at IS '作成日時（レコード作成時刻）';
-COMMENT ON COLUMN lecture_chapters.updated_by IS '更新者（レコード更新したユーザーID）';
-COMMENT ON COLUMN lecture_chapters.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN chapters.chapter_number IS 'チャプター番号';
+COMMENT ON COLUMN chapters.title IS 'チャプタータイトル';
+COMMENT ON COLUMN chapters.description IS 'チャプター説明';
+COMMENT ON COLUMN chapters.duration_minutes IS 'チャプター想定時間（分）';
+COMMENT ON COLUMN chapters.sort_order IS '並び順';
+COMMENT ON COLUMN chapters.is_active IS '有効状態（チャプターの使用可否）';
+COMMENT ON COLUMN chapters.version IS 'バージョン（楽観ロック用）';
+COMMENT ON COLUMN chapters.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN chapters.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN chapters.updated_by IS '更新者（レコード更新したユーザーID）';
+COMMENT ON COLUMN chapters.updated_at IS '更新日時（レコード更新時刻）';
+
+-- Lecture and chapter relationship table
+CREATE TABLE lecture_chapter_links (
+    id BIGSERIAL PRIMARY KEY,
+    lecture_id BIGINT NOT NULL REFERENCES lectures(id),
+    chapter_id BIGINT NOT NULL REFERENCES chapters(id),
+    sort_order INTEGER,
+    created_by BIGINT REFERENCES users(id),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_by BIGINT REFERENCES users(id),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+COMMENT ON COLUMN lecture_chapter_links.lecture_id IS '講義ID（lectures.id）';
+COMMENT ON COLUMN lecture_chapter_links.chapter_id IS 'チャプターID（chapters.id）';
+COMMENT ON COLUMN lecture_chapter_links.sort_order IS '並び順';
+COMMENT ON COLUMN lecture_chapter_links.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN lecture_chapter_links.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN lecture_chapter_links.updated_by IS '更新者（レコード更新したユーザーID）';
+COMMENT ON COLUMN lecture_chapter_links.updated_at IS '更新日時（レコード更新時刻）';
 
 -- Lecture goals table
 CREATE TABLE lecture_goals (
@@ -320,10 +338,10 @@ COMMENT ON COLUMN lecture_goals.created_at IS '作成日時（レコード作成
 COMMENT ON COLUMN lecture_goals.updated_by IS '更新者（レコード更新したユーザーID）';
 COMMENT ON COLUMN lecture_goals.updated_at IS '更新日時（レコード更新時刻）';
 
--- Lecture content blocks table
-CREATE TABLE lecture_content_blocks (
+-- Chapter content blocks table
+CREATE TABLE chapter_content_blocks (
     id BIGSERIAL PRIMARY KEY,
-    chapter_id BIGINT NOT NULL REFERENCES lecture_chapters(id),
+    chapter_id BIGINT NOT NULL REFERENCES chapters(id),
     block_type VARCHAR(50) NOT NULL,
     title VARCHAR(200) NOT NULL,
     content TEXT,
@@ -335,25 +353,26 @@ CREATE TABLE lecture_content_blocks (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
-COMMENT ON COLUMN lecture_content_blocks.chapter_id IS 'チャプターID（lecture_chapters.id）';
-COMMENT ON COLUMN lecture_content_blocks.block_type IS 'ブロック種別';
-COMMENT ON COLUMN lecture_content_blocks.title IS 'ブロックタイトル';
-COMMENT ON COLUMN lecture_content_blocks.content IS 'ブロック内容';
-COMMENT ON COLUMN lecture_content_blocks.sort_order IS '並び順';
-COMMENT ON COLUMN lecture_content_blocks.version IS 'バージョン（楽観ロック用）';
-COMMENT ON COLUMN lecture_content_blocks.created_by IS '作成者（レコード作成したユーザーID）';
-COMMENT ON COLUMN lecture_content_blocks.created_at IS '作成日時（レコード作成時刻）';
-COMMENT ON COLUMN lecture_content_blocks.updated_by IS '更新者（レコード更新したユーザーID）';
-COMMENT ON COLUMN lecture_content_blocks.updated_at IS '更新日時（レコード更新時刻）';
+COMMENT ON COLUMN chapter_content_blocks.chapter_id IS 'チャプターID（chapters.id）';
+COMMENT ON COLUMN chapter_content_blocks.block_type IS 'ブロック種別';
+COMMENT ON COLUMN chapter_content_blocks.title IS 'ブロックタイトル';
+COMMENT ON COLUMN chapter_content_blocks.content IS 'ブロック内容';
+COMMENT ON COLUMN chapter_content_blocks.sort_order IS '並び順';
+COMMENT ON COLUMN chapter_content_blocks.version IS 'バージョン（楽観ロック用）';
+COMMENT ON COLUMN chapter_content_blocks.created_by IS '作成者（レコード作成したユーザーID）';
+COMMENT ON COLUMN chapter_content_blocks.created_at IS '作成日時（レコード作成時刻）';
+COMMENT ON COLUMN chapter_content_blocks.updated_by IS '更新者（レコード更新したユーザーID）';
+COMMENT ON COLUMN chapter_content_blocks.updated_at IS '更新日時（レコード更新時刻）';
 
 -- Performance indexes
 CREATE INDEX idx_weeks_month ON weeks(month_id);
 CREATE INDEX idx_days_week ON days(week_id);
 CREATE INDEX idx_lectures_day ON lectures(day_id);
 CREATE INDEX idx_lectures_active ON lectures(is_active);
-CREATE INDEX idx_lecture_chapters_lecture ON lecture_chapters(lecture_id);
 CREATE INDEX idx_lecture_goals_lecture ON lecture_goals(lecture_id);
-CREATE INDEX idx_content_blocks_chapter ON lecture_content_blocks(chapter_id);
+CREATE INDEX idx_content_blocks_chapter ON chapter_content_blocks(chapter_id);
+CREATE INDEX idx_lecture_chapter_links_lecture ON lecture_chapter_links(lecture_id);
+CREATE INDEX idx_lecture_chapter_links_chapter ON lecture_chapter_links(chapter_id);
 
 -- Unique constraints
 ALTER TABLE weeks ADD CONSTRAINT unique_week_per_month UNIQUE(month_id, week_number);
@@ -364,9 +383,10 @@ COMMENT ON TABLE months IS '月テーブル（3ヶ月のカリキュラム月を
 COMMENT ON TABLE weeks IS '週テーブル（18週のカリキュラム週を管理）';
 COMMENT ON TABLE days IS '日テーブル（54日のカリキュラム日を管理）';
 COMMENT ON TABLE lectures IS '講義テーブル（講義の基本情報を管理）';
-COMMENT ON TABLE lecture_chapters IS '講義チャプターテーブル（講義内の章情報を管理）';
+COMMENT ON TABLE chapters IS 'チャプターテーブル（章情報を管理）';
+COMMENT ON TABLE lecture_chapter_links IS '講義チャプター関連テーブル（講義とチャプターの紐付け）';
 COMMENT ON TABLE lecture_goals IS '講義目標テーブル（講義の学習目標を管理）';
-COMMENT ON TABLE lecture_content_blocks IS '講義コンテンツブロックテーブル（チャプター内のコンテンツを管理）';
+COMMENT ON TABLE chapter_content_blocks IS 'チャプターコンテンツブロックテーブル（チャプター内のコンテンツを管理）';
 -- V002: Create Training Management Tables
 -- Creates training programs, schedules, assignments, and user role extensions
 -- Supports instructor and student management with course copying functionality


### PR DESCRIPTION
## Summary
- replace lecture_chapters with chapters and lecture_chapter_links
- redirect question/quiz tables to chapters instead of lectures
- add chapter-based indexes and constraints
- rename lecture_content_blocks table to chapter_content_blocks and update mappings

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68af94eb01c48324b8f2f70791bdedd3