### PR TITLE
refactor: switch lecture references to chapter

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
@@ -123,12 +123,14 @@ public class LectureViewController extends AbstractController {
         }
         model.addAttribute("chapterContentBlocks", chapterContentBlocks);
 
-        // 理解度テストのクイズ問題を取得
-        List<QuizQuestionBank> quizQuestions = quizQuestionBankService.findByLectureId(lecture.getId());
+        // 理解度テストと演習問題をチャプター単位で取得
+        List<QuizQuestionBank> quizQuestions = new ArrayList<>();
+        List<QuestionBank> exercises = new ArrayList<>();
+        for (Chapter chapter : chapters) {
+            quizQuestions.addAll(quizQuestionBankService.findByChapterId(chapter.getId()));
+            exercises.addAll(questionBankService.findByChapterIdOrderByQuestionNumber(chapter.getId()));
+        }
         model.addAttribute("quizQuestions", quizQuestions);
-
-        // 演習問題と追加リソースを設定
-        List<QuestionBank> exercises = questionBankService.findByLectureIdOrderByQuestionNumber(lecture.getId());
         model.addAttribute("exercises", exercises);
 
         model.addAttribute("additionalResources", parseJsonField(getAdditionalResourcesJson(lecture), List.class));

--- a/src/main/java/jp/co/apsa/giiku/controller/QuestionBankController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/QuestionBankController.java
@@ -80,4 +80,11 @@ public class QuestionBankController extends AbstractController {
         List<QuestionBank> questions = questionBankService.searchByQuestionText(query);
         return ResponseEntity.ok(questions);
     }
+
+    /** チャプターIDで問題を取得 */
+    @GetMapping("/chapter/{chapterId}")
+    public ResponseEntity<List<QuestionBank>> getByChapter(@PathVariable Long chapterId) {
+        List<QuestionBank> questions = questionBankService.findByChapterIdOrderByQuestionNumber(chapterId);
+        return ResponseEntity.ok(questions);
+    }
 }

--- a/src/main/java/jp/co/apsa/giiku/domain/entity/QuestionBank.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/entity/QuestionBank.java
@@ -19,8 +19,9 @@ public class QuestionBank {
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "lecture_id", nullable = false)
-    private Long lectureId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chapter_id", nullable = false)
+    private Chapter chapter;
 
     @Column(name = "question_number", nullable = false)
     private Integer questionNumber;
@@ -75,14 +76,35 @@ public class QuestionBank {
         this.id = id;
     }
 
-    /** getLectureId メソッド */
-    public Long getLectureId() {
-        return lectureId;
+    /** getChapter メソッド */
+    public Chapter getChapter() {
+        return chapter;
     }
 
-    /** setLectureId メソッド */
-    public void setLectureId(Long lectureId) {
-        this.lectureId = lectureId;
+    /** setChapter メソッド */
+    public void setChapter(Chapter chapter) {
+        this.chapter = chapter;
+    }
+
+    /**
+     * chapterId のエイリアス getter
+     *
+     * @return chapterId
+     */
+    public Long getChapterId() {
+        return chapter != null ? chapter.getId() : null;
+    }
+
+    /**
+     * chapterId のエイリアス setter
+     *
+     * @param chapterId chapterId
+     */
+    public void setChapterId(Long chapterId) {
+        if (this.chapter == null) {
+            this.chapter = new Chapter();
+        }
+        this.chapter.setId(chapterId);
     }
 
     /** getQuestionNumber メソッド */
@@ -238,7 +260,7 @@ public class QuestionBank {
     public String toString() {
         return "QuestionBank{" +
                 "id=" + id +
-                ", lectureId=" + lectureId +
+                ", chapterId=" + getChapterId() +
                 ", questionNumber=" + questionNumber +
                 ", questionType='" + questionType + '\'' +
                 ", difficultyLevel='" + difficultyLevel + '\'' +

--- a/src/main/java/jp/co/apsa/giiku/domain/entity/Quiz.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/entity/Quiz.java
@@ -30,8 +30,9 @@ public class Quiz {
     @Column(name = "training_program_id")
     private Long trainingProgramId;
 
-    @Column(name = "lecture_id")
-    private Long lectureId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chapter_id")
+    private Chapter chapter;
 
     @Column(name = "student_id", nullable = false)
     private Long studentId;
@@ -157,13 +158,34 @@ public class Quiz {
     public void setTrainingProgramId(Long trainingProgramId) {
         this.trainingProgramId = trainingProgramId;
     }
-    /** getLectureId メソッド */
-    public Long getLectureId() {
-        return lectureId;
+    /** getChapter メソッド */
+    public Chapter getChapter() {
+        return chapter;
     }
-    /** setLectureId メソッド */
-    public void setLectureId(Long lectureId) {
-        this.lectureId = lectureId;
+    /** setChapter メソッド */
+    public void setChapter(Chapter chapter) {
+        this.chapter = chapter;
+    }
+
+    /**
+     * chapterId のエイリアス getter
+     *
+     * @return chapterId
+     */
+    public Long getChapterId() {
+        return chapter != null ? chapter.getId() : null;
+    }
+
+    /**
+     * chapterId のエイリアス setter
+     *
+     * @param chapterId chapterId
+     */
+    public void setChapterId(Long chapterId) {
+        if (this.chapter == null) {
+            this.chapter = new Chapter();
+        }
+        this.chapter.setId(chapterId);
     }
     /** getStudentId メソッド */
     public Long getStudentId() {

--- a/src/main/java/jp/co/apsa/giiku/domain/entity/QuizQuestionBank.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/entity/QuizQuestionBank.java
@@ -19,8 +19,9 @@ public class QuizQuestionBank {
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "lecture_id", nullable = false)
-    private Long lectureId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chapter_id", nullable = false)
+    private Chapter chapter;
 
     @Column(name = "question_number", nullable = false)
     private Integer questionNumber;
@@ -93,14 +94,35 @@ public class QuizQuestionBank {
         this.id = id;
     }
 
-    /** getLectureId メソッド */
-    public Long getLectureId() {
-        return lectureId;
+    /** getChapter メソッド */
+    public Chapter getChapter() {
+        return chapter;
     }
 
-    /** setLectureId メソッド */
-    public void setLectureId(Long lectureId) {
-        this.lectureId = lectureId;
+    /** setChapter メソッド */
+    public void setChapter(Chapter chapter) {
+        this.chapter = chapter;
+    }
+
+    /**
+     * chapterId のエイリアス getter
+     *
+     * @return chapterId
+     */
+    public Long getChapterId() {
+        return chapter != null ? chapter.getId() : null;
+    }
+
+    /**
+     * chapterId のエイリアス setter
+     *
+     * @param chapterId chapterId
+     */
+    public void setChapterId(Long chapterId) {
+        if (this.chapter == null) {
+            this.chapter = new Chapter();
+        }
+        this.chapter.setId(chapterId);
     }
 
     /** getQuestionNumber メソッド */

--- a/src/main/java/jp/co/apsa/giiku/domain/repository/QuestionBankRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/QuestionBankRepository.java
@@ -3,6 +3,7 @@ package jp.co.apsa.giiku.domain.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import jp.co.apsa.giiku.domain.entity.QuestionBank;
 
@@ -51,12 +52,13 @@ public interface QuestionBankRepository extends JpaRepository<QuestionBank, Long
     List<QuestionBank> findByQuestionTextContainingIgnoreCaseAndIsActiveTrue(String text);
 
     /**
-     * 講義IDで検索し、問題番号の昇順で取得します。
+     * チャプターIDで検索し、問題番号の昇順で取得します。
      *
-     * @param lectureId 講義ID
+     * @param chapterId チャプターID
      * @return 該当する問題一覧
      */
-    List<QuestionBank> findByLectureIdOrderByQuestionNumber(Long lectureId);
+    @Query("SELECT q FROM QuestionBank q WHERE q.chapter.id = :chapterId ORDER BY q.questionNumber")
+    List<QuestionBank> findByChapterIdOrderByQuestionNumber(@Param("chapterId") Long chapterId);
 
     /**
      * 難易度別の問題数を取得します。

--- a/src/main/java/jp/co/apsa/giiku/domain/repository/QuizQuestionBankRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/QuizQuestionBankRepository.java
@@ -2,6 +2,8 @@ package jp.co.apsa.giiku.domain.repository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import jp.co.apsa.giiku.domain.entity.QuizQuestionBank;
 
@@ -16,10 +18,11 @@ import jp.co.apsa.giiku.domain.entity.QuizQuestionBank;
 public interface QuizQuestionBankRepository extends JpaRepository<QuizQuestionBank, Long> {
 
     /**
-     * 指定された講義IDのクイズ問題を問題番号順に取得します。
+     * 指定されたチャプターIDのクイズ問題を問題番号順に取得します。
      *
-     * @param lectureId 講義ID
+     * @param chapterId チャプターID
      * @return クイズ問題一覧
      */
-    List<QuizQuestionBank> findByLectureIdOrderByQuestionNumber(Long lectureId);
+    @Query("SELECT q FROM QuizQuestionBank q WHERE q.chapter.id = :chapterId ORDER BY q.questionNumber")
+    List<QuizQuestionBank> findByChapterIdOrderByQuestionNumber(@Param("chapterId") Long chapterId);
 }

--- a/src/main/java/jp/co/apsa/giiku/dto/QuizRequest.java
+++ b/src/main/java/jp/co/apsa/giiku/dto/QuizRequest.java
@@ -22,7 +22,7 @@ public class QuizRequest {
 
     private Long trainingProgramId;
 
-    private Long lectureId;
+    private Long chapterId;
 
     private Long studentId;
 
@@ -89,10 +89,10 @@ public class QuizRequest {
     public Long getTrainingProgramId() { return trainingProgramId; }
     /** setTrainingProgramId メソッド */
     public void setTrainingProgramId(Long trainingProgramId) { this.trainingProgramId = trainingProgramId; }
-    /** getLectureId メソッド */
-    public Long getLectureId() { return lectureId; }
-    /** setLectureId メソッド */
-    public void setLectureId(Long lectureId) { this.lectureId = lectureId; }
+    /** getChapterId メソッド */
+    public Long getChapterId() { return chapterId; }
+    /** setChapterId メソッド */
+    public void setChapterId(Long chapterId) { this.chapterId = chapterId; }
     /** getStudentId メソッド */
     public Long getStudentId() { return studentId; }
     /** setStudentId メソッド */

--- a/src/main/java/jp/co/apsa/giiku/dto/QuizResponse.java
+++ b/src/main/java/jp/co/apsa/giiku/dto/QuizResponse.java
@@ -16,7 +16,7 @@ public class QuizResponse {
     private String title;
     private String description;
     private Long trainingProgramId;
-    private Long lectureId;
+    private Long chapterId;
     private Long studentId;
     private Long instructorId;
     private Long companyId;
@@ -45,7 +45,7 @@ public class QuizResponse {
     // 全フィールドのコンストラクタ
     /** QuizResponse メソッド */
     public QuizResponse(Long id, String title, String description, Long trainingProgramId,
-                       Long lectureId, Long studentId, Long instructorId, Long companyId,
+                       Long chapterId, Long studentId, Long instructorId, Long companyId,
                        String quizStatus, BigDecimal timeLimit, BigDecimal maxScore,
                        BigDecimal passingScore, Integer attemptLimit, Integer currentAttempt,
                        LocalDateTime startTime, LocalDateTime endTime, LocalDateTime submissionTime,
@@ -56,7 +56,7 @@ public class QuizResponse {
         this.title = title;
         this.description = description;
         this.trainingProgramId = trainingProgramId;
-        this.lectureId = lectureId;
+        this.chapterId = chapterId;
         this.studentId = studentId;
         this.instructorId = instructorId;
         this.companyId = companyId;
@@ -126,10 +126,10 @@ public class QuizResponse {
     public Long getTrainingProgramId() { return trainingProgramId; }
     /** setTrainingProgramId メソッド */
     public void setTrainingProgramId(Long trainingProgramId) { this.trainingProgramId = trainingProgramId; }
-    /** getLectureId メソッド */
-    public Long getLectureId() { return lectureId; }
-    /** setLectureId メソッド */
-    public void setLectureId(Long lectureId) { this.lectureId = lectureId; }
+    /** getChapterId メソッド */
+    public Long getChapterId() { return chapterId; }
+    /** setChapterId メソッド */
+    public void setChapterId(Long chapterId) { this.chapterId = chapterId; }
     /** getStudentId メソッド */
     public Long getStudentId() { return studentId; }
     /** setStudentId メソッド */

--- a/src/main/java/jp/co/apsa/giiku/service/QuestionBankService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/QuestionBankService.java
@@ -121,11 +121,11 @@ public class QuestionBankService {
     }
 
     @Transactional(readOnly = true)
-    public List<QuestionBank> findByLectureIdOrderByQuestionNumber(Long lectureId) {
-        if (lectureId == null) {
-            throw new IllegalArgumentException("講義IDは必須です");
+    public List<QuestionBank> findByChapterIdOrderByQuestionNumber(Long chapterId) {
+        if (chapterId == null) {
+            throw new IllegalArgumentException("チャプターIDは必須です");
         }
-        return questionBankRepository.findByLectureIdOrderByQuestionNumber(lectureId);
+        return questionBankRepository.findByChapterIdOrderByQuestionNumber(chapterId);
     }
 
     @Transactional(readOnly = true)
@@ -142,8 +142,8 @@ public class QuestionBankService {
         if (question == null) {
             throw new IllegalArgumentException("問題は必須です");
         }
-        if (question.getLectureId() == null) {
-            throw new IllegalArgumentException("講義IDは必須です");
+        if (question.getChapterId() == null) {
+            throw new IllegalArgumentException("チャプターIDは必須です");
         }
         if (question.getQuestionNumber() == null) {
             throw new IllegalArgumentException("問題番号は必須です");

--- a/src/main/java/jp/co/apsa/giiku/service/QuizQuestionBankService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/QuizQuestionBankService.java
@@ -23,13 +23,13 @@ public class QuizQuestionBankService {
     private QuizQuestionBankRepository quizQuestionBankRepository;
 
     /**
-     * 指定された講義IDのクイズ問題を取得します。
+     * 指定されたチャプターIDのクイズ問題を取得します。
      *
-     * @param lectureId 講義ID
+     * @param chapterId チャプターID
      * @return クイズ問題一覧
      */
     @Transactional(readOnly = true)
-    public List<QuizQuestionBank> findByLectureId(Long lectureId) {
-        return quizQuestionBankRepository.findByLectureIdOrderByQuestionNumber(lectureId);
+    public List<QuizQuestionBank> findByChapterId(Long chapterId) {
+        return quizQuestionBankRepository.findByChapterIdOrderByQuestionNumber(chapterId);
     }
 }

--- a/src/main/java/jp/co/apsa/giiku/service/QuizService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/QuizService.java
@@ -468,6 +468,10 @@ public class QuizService {
             throw new IllegalArgumentException("プログラムIDは必須です");
         }
 
+        if (quiz.getChapterId() == null) {
+            throw new IllegalArgumentException("チャプターIDは必須です");
+        }
+
         // 学生存在チェック
         if (!studentProfileRepository.existsById(quiz.getStudentId())) {
             throw new IllegalArgumentException("指定された学生が存在しません");


### PR DESCRIPTION
## Summary
- replace `lectureId` with chapter relationship in quiz and question bank entities
- update repositories, services, controllers, DTOs to search by `chapterId`
- aggregate chapter-based questions in lecture view

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68afdd686ab483248cca63b7ccccd1f2