### PR TITLE
講義別問題取得の条件見直しとサービス検証テスト追加

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/domain/repository/QuestionBankRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/QuestionBankRepository.java
@@ -61,12 +61,12 @@ public interface QuestionBankRepository extends JpaRepository<QuestionBank, Long
     List<QuestionBank> findByChapterIdOrderByQuestionNumber(@Param("chapterId") Long chapterId);
 
     /**
-     * 講義IDで検索し、チャプターの並び順と問題番号の昇順で取得します。
+     * 講義IDで有効な問題を検索し、チャプターの並び順と問題番号の昇順で取得します。
      *
      * @param lectureId 講義ID
-     * @return 該当する問題一覧
+     * @return 該当する有効な問題一覧
      */
-    @Query("SELECT q FROM QuestionBank q JOIN LectureChapterLink l ON q.chapter = l.chapter WHERE l.lectureId = :lectureId ORDER BY l.sortOrder, q.questionNumber")
+    @Query("SELECT q FROM QuestionBank q JOIN LectureChapterLink l ON q.chapter.id = l.chapter.id WHERE l.lectureId = :lectureId AND q.isActive = true ORDER BY l.sortOrder, q.questionNumber")
     List<QuestionBank> findByLectureIdOrderByChapterAndQuestionNumber(@Param("lectureId") Long lectureId);
 
     /**

--- a/src/main/java/jp/co/apsa/giiku/domain/repository/QuizQuestionBankRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/QuizQuestionBankRepository.java
@@ -27,11 +27,11 @@ public interface QuizQuestionBankRepository extends JpaRepository<QuizQuestionBa
     List<QuizQuestionBank> findByChapterIdOrderByQuestionNumber(@Param("chapterId") Long chapterId);
 
     /**
-     * 指定された講義IDのクイズ問題をチャプター順・問題番号順に取得します。
+     * 指定された講義IDの有効なクイズ問題をチャプター順・問題番号順に取得します。
      *
      * @param lectureId 講義ID
      * @return クイズ問題一覧
      */
-    @Query("SELECT q FROM QuizQuestionBank q JOIN LectureChapterLink l ON q.chapter = l.chapter WHERE l.lectureId = :lectureId ORDER BY l.sortOrder, q.questionNumber")
+    @Query("SELECT q FROM QuizQuestionBank q JOIN LectureChapterLink l ON q.chapter.id = l.chapter.id WHERE l.lectureId = :lectureId AND q.isActive = true ORDER BY l.sortOrder, q.questionNumber")
     List<QuizQuestionBank> findByLectureIdOrderByChapterAndQuestionNumber(@Param("lectureId") Long lectureId);
 }

--- a/src/test/java/jp/co/apsa/giiku/service/QuestionBankServiceTest.java
+++ b/src/test/java/jp/co/apsa/giiku/service/QuestionBankServiceTest.java
@@ -1,0 +1,110 @@
+package jp.co.apsa.giiku.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import jp.co.apsa.giiku.domain.entity.Chapter;
+import jp.co.apsa.giiku.domain.entity.LectureChapterLink;
+import jp.co.apsa.giiku.domain.entity.QuestionBank;
+import jp.co.apsa.giiku.domain.repository.ChapterRepository;
+import jp.co.apsa.giiku.domain.repository.LectureChapterLinkRepository;
+import jp.co.apsa.giiku.domain.repository.QuestionBankRepository;
+
+/**
+ * QuestionBankService のテストクラス。
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class QuestionBankServiceTest {
+
+    @Autowired
+    private QuestionBankService questionBankService;
+
+    @Autowired
+    private ChapterRepository chapterRepository;
+
+    @Autowired
+    private QuestionBankRepository questionBankRepository;
+
+    @Autowired
+    private LectureChapterLinkRepository lectureChapterLinkRepository;
+
+    /**
+     * 講義IDで有効な問題のみがチャプター順・問題番号順で取得できることを検証します。
+     *
+     * @author 株式会社アプサ
+     * @version 1.0
+     * @since 2025
+     */
+    @Test
+    public void testFindByLectureIdReturnsActiveQuestions() {
+        Chapter ch1 = new Chapter();
+        ch1.setChapterNumber(1);
+        ch1.setTitle("Ch1");
+        ch1 = chapterRepository.saveAndFlush(ch1);
+
+        Chapter ch2 = new Chapter();
+        ch2.setChapterNumber(2);
+        ch2.setTitle("Ch2");
+        ch2 = chapterRepository.saveAndFlush(ch2);
+
+        LectureChapterLink link1 = new LectureChapterLink();
+        link1.setLectureId(1L);
+        link1.setChapter(ch1);
+        link1.setSortOrder(2);
+        lectureChapterLinkRepository.save(link1);
+
+        LectureChapterLink link2 = new LectureChapterLink();
+        link2.setLectureId(1L);
+        link2.setChapter(ch2);
+        link2.setSortOrder(1);
+        lectureChapterLinkRepository.save(link2);
+
+        QuestionBank q1 = new QuestionBank();
+        q1.setChapter(ch2);
+        q1.setQuestionNumber(1);
+        q1.setQuestionType("multiple_choice");
+        q1.setQuestionText("Q1");
+        q1.setDifficultyLevel("easy");
+        q1.setIsActive(true);
+        questionBankRepository.save(q1);
+
+        QuestionBank q2 = new QuestionBank();
+        q2.setChapter(ch1);
+        q2.setQuestionNumber(1);
+        q2.setQuestionType("multiple_choice");
+        q2.setQuestionText("Q2");
+        q2.setDifficultyLevel("easy");
+        q2.setIsActive(true);
+        questionBankRepository.save(q2);
+
+        QuestionBank q3 = new QuestionBank();
+        q3.setChapter(ch1);
+        q3.setQuestionNumber(2);
+        q3.setQuestionType("multiple_choice");
+        q3.setQuestionText("Q3");
+        q3.setDifficultyLevel("easy");
+        q3.setIsActive(false);
+        questionBankRepository.save(q3);
+
+        List<LectureChapterLink> links = lectureChapterLinkRepository.findByLectureIdOrderBySortOrder(1L);
+        assertEquals(2, links.size());
+
+        List<QuestionBank> result = questionBankService.findByLectureId(1L);
+        assertEquals(2, result.size());
+        assertEquals("Q1", result.get(0).getQuestionText());
+        assertEquals("Q2", result.get(1).getQuestionText());
+    }
+}

--- a/src/test/java/jp/co/apsa/giiku/service/QuizQuestionBankServiceTest.java
+++ b/src/test/java/jp/co/apsa/giiku/service/QuizQuestionBankServiceTest.java
@@ -1,0 +1,110 @@
+package jp.co.apsa.giiku.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import jp.co.apsa.giiku.domain.entity.Chapter;
+import jp.co.apsa.giiku.domain.entity.LectureChapterLink;
+import jp.co.apsa.giiku.domain.entity.QuizQuestionBank;
+import jp.co.apsa.giiku.domain.repository.ChapterRepository;
+import jp.co.apsa.giiku.domain.repository.LectureChapterLinkRepository;
+import jp.co.apsa.giiku.domain.repository.QuizQuestionBankRepository;
+
+/**
+ * QuizQuestionBankService のテストクラス。
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class QuizQuestionBankServiceTest {
+
+    @Autowired
+    private QuizQuestionBankService quizQuestionBankService;
+
+    @Autowired
+    private ChapterRepository chapterRepository;
+
+    @Autowired
+    private QuizQuestionBankRepository quizQuestionBankRepository;
+
+    @Autowired
+    private LectureChapterLinkRepository lectureChapterLinkRepository;
+
+    /**
+     * 講義IDで有効なクイズ問題のみがチャプター順・問題番号順で取得できることを検証します。
+     *
+     * @author 株式会社アプサ
+     * @version 1.0
+     * @since 2025
+     */
+    @Test
+    public void testFindByLectureIdReturnsActiveQuestions() {
+        Chapter ch1 = new Chapter();
+        ch1.setChapterNumber(1);
+        ch1.setTitle("Ch1");
+        ch1 = chapterRepository.saveAndFlush(ch1);
+
+        Chapter ch2 = new Chapter();
+        ch2.setChapterNumber(2);
+        ch2.setTitle("Ch2");
+        ch2 = chapterRepository.saveAndFlush(ch2);
+
+        LectureChapterLink link1 = new LectureChapterLink();
+        link1.setLectureId(1L);
+        link1.setChapter(ch1);
+        link1.setSortOrder(2);
+        lectureChapterLinkRepository.save(link1);
+
+        LectureChapterLink link2 = new LectureChapterLink();
+        link2.setLectureId(1L);
+        link2.setChapter(ch2);
+        link2.setSortOrder(1);
+        lectureChapterLinkRepository.save(link2);
+
+        QuizQuestionBank qq1 = new QuizQuestionBank();
+        qq1.setChapter(ch2);
+        qq1.setQuestionNumber(1);
+        qq1.setQuestionType("single");
+        qq1.setQuestionText("QQ1");
+        qq1.setCorrectAnswer("A");
+        qq1.setIsActive(true);
+        quizQuestionBankRepository.save(qq1);
+
+        QuizQuestionBank qq2 = new QuizQuestionBank();
+        qq2.setChapter(ch1);
+        qq2.setQuestionNumber(1);
+        qq2.setQuestionType("single");
+        qq2.setQuestionText("QQ2");
+        qq2.setCorrectAnswer("A");
+        qq2.setIsActive(true);
+        quizQuestionBankRepository.save(qq2);
+
+        QuizQuestionBank qq3 = new QuizQuestionBank();
+        qq3.setChapter(ch1);
+        qq3.setQuestionNumber(2);
+        qq3.setQuestionType("single");
+        qq3.setQuestionText("QQ3");
+        qq3.setCorrectAnswer("A");
+        qq3.setIsActive(false);
+        quizQuestionBankRepository.save(qq3);
+
+        List<LectureChapterLink> links = lectureChapterLinkRepository.findByLectureIdOrderBySortOrder(1L);
+        assertEquals(2, links.size());
+
+        List<QuizQuestionBank> result = quizQuestionBankService.findByLectureId(1L);
+        assertEquals(2, result.size());
+        assertEquals("QQ1", result.get(0).getQuestionText());
+        assertEquals("QQ2", result.get(1).getQuestionText());
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driverClassName: org.h2.Driver
+    username: sa
+    password: 
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+    show-sql: true
+  flyway:
+    enabled: false
+logging:
+  config: classpath:logback-test.xml

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,10 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
## 概要
- 講義別問題取得クエリでチャプターIDによる結合と有効フラグの条件を追加
- QuestionBankService/QuizQuestionBankService の講義ID検索を検証するテストを追加
- テスト用のH2設定と簡易ログ設定を追加

## テスト
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68b14b2ac1e08324870d80a7755c0634