### PR TITLE
feat: add debug logs for lecture-based question retrieval

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
@@ -125,6 +125,7 @@ public class LectureViewController extends AbstractController {
 
         // 理解度テストと演習問題を講義IDから取得しチャプターごとに格納
         List<QuizQuestionBank> quizQuestions = quizQuestionBankService.findByLectureId(lecture.getId());
+        logger.debug("Fetched {} quiz questions for lectureId={}", quizQuestions.size(), lecture.getId());
         Map<Long, List<QuizQuestionBank>> quizQuestionsByChapter = new HashMap<>();
         for (QuizQuestionBank quiz : quizQuestions) {
             Long chapterId = quiz.getChapter().getId();
@@ -133,6 +134,7 @@ public class LectureViewController extends AbstractController {
         model.addAttribute("quizQuestionsByChapter", quizQuestionsByChapter);
 
         List<QuestionBank> exercises = questionBankService.findByLectureId(lecture.getId());
+        logger.debug("Fetched {} exercise questions for lectureId={}", exercises.size(), lecture.getId());
         Map<Long, List<QuestionBank>> exercisesByChapter = new HashMap<>();
         for (QuestionBank exercise : exercises) {
             Long chapterId = exercise.getChapter().getId();

--- a/src/main/java/jp/co/apsa/giiku/controller/QuestionBankController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/QuestionBankController.java
@@ -2,6 +2,8 @@ package jp.co.apsa.giiku.controller;
 
 import jp.co.apsa.giiku.domain.entity.QuestionBank;
 import jp.co.apsa.giiku.service.QuestionBankService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,6 +28,8 @@ import java.util.Optional;
 @RequestMapping("/api/question-banks")
 @CrossOrigin(origins = "*", maxAge = 3600)
 public class QuestionBankController extends AbstractController {
+
+    private static final Logger logger = LoggerFactory.getLogger(QuestionBankController.class);
 
     @Autowired
     private QuestionBankService questionBankService;
@@ -91,7 +95,9 @@ public class QuestionBankController extends AbstractController {
     /** 講義IDで問題を取得 */
     @GetMapping("/lecture/{lectureId}")
     public ResponseEntity<List<QuestionBank>> getByLecture(@PathVariable Long lectureId) {
+        logger.debug("Fetching questions via API for lectureId={}", lectureId);
         List<QuestionBank> questions = questionBankService.findByLectureId(lectureId);
+        logger.debug("Returning {} questions for lectureId={}", questions.size(), lectureId);
         return ResponseEntity.ok(questions);
     }
 }

--- a/src/main/java/jp/co/apsa/giiku/controller/QuizQuestionBankController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/QuizQuestionBankController.java
@@ -2,6 +2,8 @@ package jp.co.apsa.giiku.controller;
 
 import jp.co.apsa.giiku.domain.entity.QuizQuestionBank;
 import jp.co.apsa.giiku.service.QuizQuestionBankService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +24,8 @@ import java.util.List;
 @CrossOrigin(origins = "*", maxAge = 3600)
 public class QuizQuestionBankController extends AbstractController {
 
+    private static final Logger logger = LoggerFactory.getLogger(QuizQuestionBankController.class);
+
     @Autowired
     private QuizQuestionBankService quizQuestionBankService;
 
@@ -35,7 +39,9 @@ public class QuizQuestionBankController extends AbstractController {
     /** 講義IDでクイズ問題を取得 */
     @GetMapping("/lecture/{lectureId}")
     public ResponseEntity<List<QuizQuestionBank>> getByLecture(@PathVariable Long lectureId) {
+        logger.debug("Fetching quiz questions via API for lectureId={}", lectureId);
         List<QuizQuestionBank> questions = quizQuestionBankService.findByLectureId(lectureId);
+        logger.debug("Returning {} quiz questions for lectureId={}", questions.size(), lectureId);
         return ResponseEntity.ok(questions);
     }
 }

--- a/src/main/java/jp/co/apsa/giiku/service/QuestionBankService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/QuestionBankService.java
@@ -2,6 +2,8 @@ package jp.co.apsa.giiku.service;
 
 import jp.co.apsa.giiku.domain.entity.QuestionBank;
 import jp.co.apsa.giiku.domain.repository.QuestionBankRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,6 +27,8 @@ import com.github.dozermapper.core.Mapper;
 @Service
 @Transactional
 public class QuestionBankService {
+
+    private static final Logger logger = LoggerFactory.getLogger(QuestionBankService.class);
 
     @Autowired
     private QuestionBankRepository questionBankRepository;
@@ -139,7 +143,10 @@ public class QuestionBankService {
         if (lectureId == null) {
             throw new IllegalArgumentException("講義IDは必須です");
         }
-        return questionBankRepository.findByLectureIdOrderByChapterAndQuestionNumber(lectureId);
+        logger.debug("Fetching exercise questions for lectureId={}", lectureId);
+        List<QuestionBank> result = questionBankRepository.findByLectureIdOrderByChapterAndQuestionNumber(lectureId);
+        logger.debug("Retrieved {} exercise questions for lectureId={}", result.size(), lectureId);
+        return result;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/jp/co/apsa/giiku/service/QuizQuestionBankService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/QuizQuestionBankService.java
@@ -1,6 +1,8 @@
 package jp.co.apsa.giiku.service;
 
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +20,8 @@ import jp.co.apsa.giiku.domain.repository.QuizQuestionBankRepository;
 @Service
 @Transactional
 public class QuizQuestionBankService {
+
+    private static final Logger logger = LoggerFactory.getLogger(QuizQuestionBankService.class);
 
     @Autowired
     private QuizQuestionBankRepository quizQuestionBankRepository;
@@ -44,6 +48,9 @@ public class QuizQuestionBankService {
         if (lectureId == null) {
             throw new IllegalArgumentException("講義IDは必須です");
         }
-        return quizQuestionBankRepository.findByLectureIdOrderByChapterAndQuestionNumber(lectureId);
+        logger.debug("Fetching quiz questions for lectureId={}", lectureId);
+        List<QuizQuestionBank> result = quizQuestionBankRepository.findByLectureIdOrderByChapterAndQuestionNumber(lectureId);
+        logger.debug("Retrieved {} quiz questions for lectureId={}", result.size(), lectureId);
+        return result;
     }
 }


### PR DESCRIPTION
## Summary
- add debug logs in question/quiz controllers and services to trace lectureId and result counts
- log number of quiz and exercise questions fetched in LectureViewController

## Testing
- `./gradlew test --tests "jp.co.apsa.giiku.service.QuestionBankServiceTest"`
- `./gradlew test --tests "jp.co.apsa.giiku.service.QuizQuestionBankServiceTest"`


------
https://chatgpt.com/codex/tasks/task_b_68b4d26aa99483249f26fa1beb0098bb