### PR TITLE
feat: add student answer persistence

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/domain/entity/StudentAnswer.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/entity/StudentAnswer.java
@@ -1,0 +1,47 @@
+package jp.co.apsa.giiku.domain.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.Data;
+
+/**
+ * 学生回答エンティティ
+ * クイズの各設問に対する学生の回答を管理します。
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
+@Entity
+@Table(name = "student_answers", indexes = {
+    @Index(name = "idx_quiz_question_student", columnList = "quiz_id,question_id,student_id", unique = true)
+})
+@Data
+public class StudentAnswer {
+
+    /** 識別ID */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    /** 質問ID */
+    @Column(name = "question_id", nullable = false)
+    private Long questionId;
+
+    /** クイズID */
+    @Column(name = "quiz_id", nullable = false)
+    private Long quizId;
+
+    /** 学生ID */
+    @Column(name = "student_id", nullable = false)
+    private Long studentId;
+
+    /** 回答内容 */
+    @Column(name = "answer_text", columnDefinition = "TEXT")
+    private String answerText;
+
+    /** 回答日時 */
+    @Column(name = "submitted_at")
+    private LocalDateTime submittedAt;
+}

--- a/src/main/java/jp/co/apsa/giiku/domain/repository/StudentAnswerRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/StudentAnswerRepository.java
@@ -1,0 +1,26 @@
+package jp.co.apsa.giiku.domain.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import jp.co.apsa.giiku.domain.entity.StudentAnswer;
+
+/**
+ * 学生回答リポジトリ
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
+@Repository
+public interface StudentAnswerRepository extends JpaRepository<StudentAnswer, Long> {
+
+    /**
+     * クイズIDと学生IDで回答を取得
+     *
+     * @param quizId クイズID
+     * @param studentId 学生ID
+     * @return 回答一覧
+     */
+    List<StudentAnswer> findByQuizIdAndStudentId(Long quizId, Long studentId);
+}

--- a/src/main/java/jp/co/apsa/giiku/service/StudentAnswerService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/StudentAnswerService.java
@@ -1,0 +1,56 @@
+package jp.co.apsa.giiku.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import jp.co.apsa.giiku.domain.entity.StudentAnswer;
+import jp.co.apsa.giiku.domain.repository.StudentAnswerRepository;
+
+/**
+ * 学生回答サービス
+ * クイズ回答の保存・取得機能を提供します。
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
+@Service
+@Transactional
+public class StudentAnswerService {
+
+    @Autowired
+    private StudentAnswerRepository studentAnswerRepository;
+
+    /**
+     * 学生回答を保存
+     *
+     * @param quizId クイズID
+     * @param questionId 質問ID
+     * @param studentId 学生ID
+     * @param answerText 回答内容
+     * @return 保存された回答
+     */
+    public StudentAnswer saveAnswer(Long quizId, Long questionId, Long studentId, String answerText) {
+        StudentAnswer answer = new StudentAnswer();
+        answer.setQuizId(quizId);
+        answer.setQuestionId(questionId);
+        answer.setStudentId(studentId);
+        answer.setAnswerText(answerText);
+        answer.setSubmittedAt(LocalDateTime.now());
+        return studentAnswerRepository.save(answer);
+    }
+
+    /**
+     * クイズIDと学生IDで回答を取得
+     *
+     * @param quizId クイズID
+     * @param studentId 学生ID
+     * @return 回答一覧
+     */
+    @Transactional(readOnly = true)
+    public List<StudentAnswer> getAnswers(Long quizId, Long studentId) {
+        return studentAnswerRepository.findByQuizIdAndStudentId(quizId, studentId);
+    }
+}


### PR DESCRIPTION
## Summary
- add StudentAnswer entity and repository
- implement StudentAnswerService for saving and retrieving answers
- persist quiz answers individually via StudentAnswerService

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68b7613bea7c8324ad5b8663dbfcb03c