### PR TITLE
Add exercise answer endpoint for question banks

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/controller/QuestionBankController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/QuestionBankController.java
@@ -1,7 +1,10 @@
 package jp.co.apsa.giiku.controller;
 
 import jp.co.apsa.giiku.domain.entity.QuestionBank;
+import jp.co.apsa.giiku.dto.ExerciseAnswer;
 import jp.co.apsa.giiku.service.QuestionBankService;
+import jp.co.apsa.giiku.service.StudentAnswerService;
+import jp.co.apsa.giiku.service.LectureGradeService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +36,12 @@ public class QuestionBankController extends AbstractController {
 
     @Autowired
     private QuestionBankService questionBankService;
+
+    @Autowired
+    private StudentAnswerService studentAnswerService;
+
+    @Autowired
+    private LectureGradeService lectureGradeService;
 
     /** 問題一覧をページング形式で取得 */
     @GetMapping
@@ -99,5 +108,23 @@ public class QuestionBankController extends AbstractController {
         List<QuestionBank> questions = questionBankService.findByLectureId(lectureId);
         logger.debug("Returning {} questions for lectureId={}", questions.size(), lectureId);
         return ResponseEntity.ok(questions);
+    }
+
+    /**
+     * 演習問題の回答を保存
+     *
+     * @param id 問題ID
+     * @param exerciseAnswer 回答情報
+     * @return レスポンス
+     */
+    @PostMapping("/{id}/answer")
+    public ResponseEntity<Void> saveExerciseAnswer(@PathVariable Long id,
+                                                   @RequestBody ExerciseAnswer exerciseAnswer) {
+        logger.debug("Saving exercise answer: questionId={} studentId={}", id, exerciseAnswer.getStudentId());
+        studentAnswerService.saveExerciseAnswer(id, exerciseAnswer.getStudentId(), exerciseAnswer.getAnswerText());
+        if (exerciseAnswer.getLectureId() != null && exerciseAnswer.getCorrect() != null) {
+            lectureGradeService.updateExerciseStats(exerciseAnswer.getLectureId(), exerciseAnswer.getCorrect());
+        }
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/jp/co/apsa/giiku/domain/repository/LectureGradeRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/LectureGradeRepository.java
@@ -3,6 +3,7 @@ package jp.co.apsa.giiku.domain.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import jp.co.apsa.giiku.domain.entity.LectureGrade;
+import java.util.Optional;
 
 /**
  * LectureGradeのリポジトリインターフェース
@@ -14,5 +15,13 @@ import jp.co.apsa.giiku.domain.entity.LectureGrade;
 @Repository
 public interface LectureGradeRepository extends JpaRepository<LectureGrade, Long> {
     // カスタムクエリメソッドをここに追加
+
+    /**
+     * 講義IDで成績を検索
+     *
+     * @param lectureId 講義ID
+     * @return 成績情報
+     */
+    Optional<LectureGrade> findByLectureId(Long lectureId);
 }
 

--- a/src/main/java/jp/co/apsa/giiku/dto/ExerciseAnswer.java
+++ b/src/main/java/jp/co/apsa/giiku/dto/ExerciseAnswer.java
@@ -1,0 +1,85 @@
+package jp.co.apsa.giiku.dto;
+
+/**
+ * 演習回答DTO
+ *
+ * 学生が演習問題に回答した内容を表します。
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
+public class ExerciseAnswer {
+
+    /** 学生ID */
+    private Long studentId;
+
+    /** 講義ID */
+    private Long lectureId;
+
+    /** 回答内容 */
+    private String answerText;
+
+    /** 正解かどうか */
+    private Boolean correct;
+
+    /** デフォルトコンストラクタ */
+    public ExerciseAnswer() {
+    }
+
+    /**
+     * @return 学生ID
+     */
+    public Long getStudentId() {
+        return studentId;
+    }
+
+    /**
+     * @param studentId 学生ID
+     */
+    public void setStudentId(Long studentId) {
+        this.studentId = studentId;
+    }
+
+    /**
+     * @return 講義ID
+     */
+    public Long getLectureId() {
+        return lectureId;
+    }
+
+    /**
+     * @param lectureId 講義ID
+     */
+    public void setLectureId(Long lectureId) {
+        this.lectureId = lectureId;
+    }
+
+    /**
+     * @return 回答内容
+     */
+    public String getAnswerText() {
+        return answerText;
+    }
+
+    /**
+     * @param answerText 回答内容
+     */
+    public void setAnswerText(String answerText) {
+        this.answerText = answerText;
+    }
+
+    /**
+     * @return 正解かどうか
+     */
+    public Boolean getCorrect() {
+        return correct;
+    }
+
+    /**
+     * @param correct 正解かどうか
+     */
+    public void setCorrect(Boolean correct) {
+        this.correct = correct;
+    }
+}

--- a/src/main/java/jp/co/apsa/giiku/service/LectureGradeService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/LectureGradeService.java
@@ -70,5 +70,29 @@ public class LectureGradeService {
     public void delete(Long id) {
         lectureGradeRepository.deleteById(id);
     }
+
+    /**
+     * 演習回答結果を更新
+     *
+     * @param lectureId 講義ID
+     * @param correct 正解かどうか
+     */
+    public void updateExerciseStats(Long lectureId, boolean correct) {
+        LectureGrade grade = lectureGradeRepository.findByLectureId(lectureId)
+                .orElseGet(() -> {
+                    LectureGrade g = new LectureGrade();
+                    g.setLectureId(lectureId);
+                    g.setExerciseScore(0);
+                    g.setExerciseMaxScore(0);
+                    return g;
+                });
+        Integer maxScore = grade.getExerciseMaxScore() == null ? 0 : grade.getExerciseMaxScore();
+        grade.setExerciseMaxScore(maxScore + 1);
+        if (correct) {
+            Integer score = grade.getExerciseScore() == null ? 0 : grade.getExerciseScore();
+            grade.setExerciseScore(score + 1);
+        }
+        lectureGradeRepository.save(grade);
+    }
 }
 

--- a/src/main/java/jp/co/apsa/giiku/service/StudentAnswerService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/StudentAnswerService.java
@@ -43,6 +43,18 @@ public class StudentAnswerService {
     }
 
     /**
+     * 演習回答を保存
+     *
+     * @param questionId 質問ID
+     * @param studentId 学生ID
+     * @param answerText 回答内容
+     * @return 保存された回答
+     */
+    public StudentAnswer saveExerciseAnswer(Long questionId, Long studentId, String answerText) {
+        return saveAnswer(0L, questionId, studentId, answerText);
+    }
+
+    /**
      * クイズIDと学生IDで回答を取得
      *
      * @param quizId クイズID


### PR DESCRIPTION
## Summary
- allow students to submit exercise answers via `POST /api/question-banks/{id}/answer`
- track exercise scores through `LectureGradeService`
- introduce `ExerciseAnswer` DTO and service helper

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_b_68b763ab4db48324badfd7f980719577