### PR TITLE
Add answer monitor page for live quiz responses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,8 @@ dependencies {
     implementation 'org.webjars.npm:js-tokens:4.0.0'
     implementation 'org.webjars.npm:prismjs:1.29.0'
     implementation 'org.webjars:webjars-locator-core'
+    implementation 'org.webjars:sockjs-client:1.5.1'
+    implementation 'org.webjars:stomp-websocket:2.3.4'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok:1.18.32'

--- a/src/main/java/jp/co/apsa/giiku/controller/InstructorController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/InstructorController.java
@@ -10,6 +10,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 import jakarta.validation.Valid;
@@ -29,7 +30,7 @@ import java.util.Optional;
  * @version 1.0
  * @since 2025
  */
-@RestController
+@Controller
 @RequestMapping("/api/lms/instructors")
 @Validated
 public class InstructorController {
@@ -38,6 +39,7 @@ public class InstructorController {
     private InstructorService instructorService;
 
     /** 講師一覧取得 */
+    @ResponseBody
     @GetMapping
     public ResponseEntity<Page<Instructor>> getAllInstructors(
             @PageableDefault(size = 20) Pageable pageable) {
@@ -50,6 +52,7 @@ public class InstructorController {
     }
 
     /** 講師詳細取得 */
+    @ResponseBody
     @GetMapping("/{id}")
     public ResponseEntity<Instructor> getInstructor(@PathVariable @NotNull @Min(1) Long id) {
         try {
@@ -63,6 +66,7 @@ public class InstructorController {
     }
 
     /** 講師作成 */
+    @ResponseBody
     @PostMapping
     public ResponseEntity<Instructor> createInstructor(@Valid @RequestBody Instructor instructor) {
         try {
@@ -76,6 +80,7 @@ public class InstructorController {
     }
 
     /** 講師更新 */
+    @ResponseBody
     @PutMapping("/{id}")
     public ResponseEntity<Instructor> updateInstructor(
             @PathVariable @NotNull @Min(1) Long id,
@@ -92,6 +97,7 @@ public class InstructorController {
     }
 
     /** 評価追加 */
+    @ResponseBody
     @PostMapping("/{id}/rating")
     public ResponseEntity<Map<String, String>> addRating(
             @PathVariable @NotNull @Min(1) Long id,
@@ -106,6 +112,16 @@ public class InstructorController {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
+    }
+
+    /**
+     * 回答モニタ画面への遷移ハンドラ。
+     *
+     * @return 回答モニタテンプレート
+     */
+    @GetMapping("/monitor")
+    public String answerMonitor() {
+        return "admin/answer_monitor";
     }
 
     // リクエストクラス

--- a/src/main/resources/static/js/answer-monitor.js
+++ b/src/main/resources/static/js/answer-monitor.js
@@ -1,0 +1,39 @@
+/**
+ * 回答モニタ用スクリプト
+ * WebSocket を利用して /topic/answers/* を購読
+ * 作成日: 2025-09-02
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    const connectBtn = document.getElementById('connect-btn');
+    const quizIdInput = document.getElementById('quiz-id');
+    const answersList = document.getElementById('answers');
+    let stompClient = null;
+
+    connectBtn.addEventListener('click', () => {
+        const quizId = quizIdInput.value.trim();
+        if (!quizId) {
+            alert('クイズIDを入力してください');
+            return;
+        }
+
+        const socket = new SockJS('/ws');
+        stompClient = Stomp.over(socket);
+        stompClient.connect({}, () => {
+            stompClient.subscribe(`/topic/answers/${quizId}`, (message) => {
+                const payload = JSON.parse(message.body);
+                renderAnswers(payload);
+            });
+        });
+    });
+
+    function renderAnswers(answers) {
+        answersList.innerHTML = '';
+        Object.keys(answers).forEach(questionId => {
+            const li = document.createElement('li');
+            li.className = 'list-group-item';
+            li.textContent = `Q${questionId}: ${answers[questionId]}`;
+            answersList.appendChild(li);
+        });
+    }
+});

--- a/src/main/resources/templates/admin/answer_monitor.html
+++ b/src/main/resources/templates/admin/answer_monitor.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{_layouts/admin}">
+<head>
+    <title>回答モニタ</title>
+</head>
+<body>
+<div layout:fragment="pageheader">
+    <h2>回答モニタ</h2>
+</div>
+<section layout:fragment="content">
+    <div class="mb-3">
+        <label for="quiz-id" class="form-label">クイズID</label>
+        <div class="input-group">
+            <input type="text" id="quiz-id" class="form-control" placeholder="Quiz ID">
+            <button id="connect-btn" class="btn btn-primary">接続</button>
+        </div>
+    </div>
+    <ul id="answers" class="list-group"></ul>
+</section>
+<script src="/webjars/sockjs-client/sockjs.min.js" th:src="@{/webjars/sockjs-client/sockjs.min.js}"></script>
+<script src="/webjars/stomp-websocket/stomp.min.js" th:src="@{/webjars/stomp-websocket/stomp.min.js}"></script>
+<script src="../static/js/answer-monitor.js" th:src="@{/js/answer-monitor.js}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add SockJS and STOMP WebJar dependencies
- implement admin answer monitor page and JavaScript for subscribing to `/topic/answers/*`
- add monitor view handler in `InstructorController`

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_b_68b766f583ec832497a90433b6a281d2