### PR TITLE
feat: enable exercise answer submission

### DIFF
--- a/progress_and_planning.html
+++ b/progress_and_planning.html
@@ -343,6 +343,10 @@
             </div>
 
             <div class="bg-primary bg-opacity-10 border-start border-4 border-primary p-3 mb-3">
+                <h3 class="fw-bold mb-2"><i class="fas fa-sync-alt text-primary me-2"></i>2025-09-07: 演習回答送信機能</h3>
+                <p class="text-muted small mb-0">演習問題への回答を送信し確認できるフォームを追加。</p>
+            </div>
+            <div class="bg-primary bg-opacity-10 border-start border-4 border-primary p-3 mb-3">
                 <h3 class="fw-bold mb-2"><i class="fas fa-sync-alt text-primary me-2"></i>2025-08-30: 講義別問題取得API公開</h3>
                 <p class="text-muted small mb-0">REST APIに講義IDで問題を取得するエンドポイントを追加。</p>
             </div>
@@ -408,7 +412,7 @@
     <footer class="bg-custom-blue text-white py-3 mt-4">
         <div class="container text-center">
             <p class="mb-1">&copy; 2025 ITエンジニア育成カリキュラム All Rights Reserved.</p>
-            <p class="small mb-0">最終更新日: 2025-09-06 (Bootstrap版)</p>
+            <p class="small mb-0">最終更新日: 2025-09-07 (Bootstrap版)</p>
         </div>
     </footer>
 

--- a/src/main/resources/static/js/lecture-exercise.js
+++ b/src/main/resources/static/js/lecture-exercise.js
@@ -1,0 +1,25 @@
+async function submitExerciseAnswer(questionId, lectureId, answerText) {
+    const studentInput = document.getElementById('studentId');
+    const studentId = studentInput ? studentInput.value : null;
+    const resultEl = document.getElementById(`exercise-result-${questionId}`);
+    try {
+        const response = await fetch(`/api/question-banks/${questionId}/answer`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ lectureId: lectureId, studentId: studentId, answerText: answerText })
+        });
+        if (!response.ok) {
+            throw new Error('Network response was not ok');
+        }
+        if (resultEl) {
+            resultEl.textContent = '回答を送信しました';
+            resultEl.className = 'mt-2 text-success';
+        }
+    } catch (error) {
+        console.error('Failed to submit exercise answer', error);
+        if (resultEl) {
+            resultEl.textContent = '送信に失敗しました';
+            resultEl.className = 'mt-2 text-danger';
+        }
+    }
+}

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -192,6 +192,13 @@
                     <div th:each="exercise, exStat : ${exercisesByChapter[chapter.id]}" class="border rounded p-4 mb-4">
                         <h4 class="fw-bold text-primary mb-3" th:text="${'演習問題' + exercise.questionNumber}">演習問題タイトル</h4>
                         <p class="mb-3" th:utext="${exercise.questionText}">問題説明</p>
+                        <div class="mb-3">
+                            <textarea class="form-control" th:id="|exercise-input-${exercise.id}|" rows="3" placeholder="回答を入力してください"></textarea>
+                        </div>
+                        <button class="btn btn-success" th:onclick="|submitExerciseAnswer(${exercise.id}, ${lecture.id}, document.getElementById('exercise-input-${exercise.id}').value)|">
+                            <i class="fas fa-paper-plane me-1"></i>送信
+                        </button>
+                        <div th:id="|exercise-result-${exercise.id}|" class="mt-2"></div>
                         <button sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')"
                                 th:onclick="'toggleAnswer(\'exercise-answer' + ${exStat.count} + '\')'"
                                 class="btn btn-primary d-flex align-items-center gap-2">
@@ -311,6 +318,7 @@
     <script th:src="@{/webjars/prismjs/1.29.0/components/prism-java.min.js}"></script>
     <script th:src="@{/webjars/prismjs/1.29.0/components/prism-sql.min.js}"></script>
     <script th:src="@{/js/lecture-quiz.js}"></script>
+    <script th:src='@{/js/lecture-exercise.js}'></script>
     <script th:src="@{/js/quiz-answer-monitor.js}"></script>
 </section>
 </body>


### PR DESCRIPTION
## Summary
- add frontend script to post exercise answers
- expose text area and send button on lecture page and wire to API
- log progress entry for exercise answer submission

## Testing
- `./gradlew build`
- `npm run test:e2e` *(fails: psql: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b7787addc08324b6413d77b67a4b5c