### PR TITLE
fix: クイズ回答APIの引数調整

### DIFF
--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -1,4 +1,4 @@
-async function submitQuizAnswer(quizId, questionId) {
+async function submitQuizAnswer(questionId) {
     const studentInput = document.getElementById('studentId');
     const studentId = studentInput ? studentInput.value : null;
 
@@ -19,7 +19,7 @@ async function submitQuizAnswer(quizId, questionId) {
         const response = await fetch(`/api/quizzes/questions/${questionId}/answer`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ quizId: quizId, studentId: studentId, answer: answer })
+            body: JSON.stringify({ studentId: studentId, answer: answer })
         });
         if (!response.ok) {
             throw new Error('Network response was not ok');

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -190,7 +190,7 @@
                             </li>
                         </ol>
                         <div class="mt-2">
-                            <button class="btn btn-success" th:onclick="'submitQuizAnswer(' + ${lecture.id} + ',' + ${quiz.id} + ')'">回答送信</button>
+                            <button class="btn btn-success" th:onclick="'submitQuizAnswer(' + ${quiz.id} + ')'">回答送信</button>
                             <div th:id="'quiz-result-' + ${quiz.id}" class="mt-2"></div>
                         </div>
                         <div sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')">


### PR DESCRIPTION
## Summary
- lecture.html の回答送信ボタンから lecture.id を削除
- quizId を不要にした lecture-quiz.js を API 仕様に合わせて修正

## Testing
- `./gradlew test`
- `npm test` *(script missing)*

------
https://chatgpt.com/codex/tasks/task_b_68b788acac208324870d299ffeb893d2