### PR TITLE
講義ページの回答モニタを問題ごとに対応

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
@@ -100,6 +100,7 @@ public class LectureViewController extends AbstractController {
         setTitle(model, lecture.getTitle());
         model.addAttribute("pageTitle", lecture.getTitle());
         model.addAttribute("lecture", lecture);
+        // 以前は回答モニタ用のquestionIdをモデルに追加していたが現在は不要
 
         // 正規化されたテーブルからデータを取得
         logger.debug("=== Lecture Debug Info ===");

--- a/src/main/resources/static/js/exercise-answer-monitor.js
+++ b/src/main/resources/static/js/exercise-answer-monitor.js
@@ -6,33 +6,32 @@
  */
 
 document.addEventListener('DOMContentLoaded', () => {
-    const monitor = document.getElementById('exercise-answer-monitor');
-    if (!monitor) {
-        return;
-    }
-    const questionId = monitor.dataset.questionId;
-    if (!questionId) {
-        return;
-    }
+    const monitors = document.querySelectorAll('.exercise-answer-monitor');
+    monitors.forEach(monitor => {
+        const questionId = monitor.dataset.questionId;
+        if (!questionId) {
+            return;
+        }
 
-    fetch(`/api/question-banks/${questionId}/answers`)
-        .then(response => response.json())
-        .then(data => {
-            const list = monitor.querySelector('#exercise-student-list');
-            const display = monitor.querySelector('#exercise-answer-display');
-            if (!list || !display) {
-                return;
-            }
-            list.innerHTML = '';
-            data.forEach(row => {
-                const li = document.createElement('li');
-                li.className = 'list-group-item list-group-item-action';
-                li.textContent = row.studentName;
-                li.addEventListener('click', () => {
-                    display.textContent = row.answerText ?? '';
+        fetch(`/api/question-banks/${questionId}/answers`)
+            .then(response => response.json())
+            .then(data => {
+                const list = monitor.querySelector('.exercise-student-list');
+                const display = monitor.querySelector('.exercise-answer-display');
+                if (!list || !display) {
+                    return;
+                }
+                list.innerHTML = '';
+                data.forEach(row => {
+                    const li = document.createElement('li');
+                    li.className = 'list-group-item list-group-item-action';
+                    li.textContent = row.studentName;
+                    li.addEventListener('click', () => {
+                        display.textContent = row.answerText ?? '';
+                    });
+                    list.appendChild(li);
                 });
-                list.appendChild(li);
-            });
-        })
-        .catch(err => console.error('回答取得エラー', err));
+            })
+            .catch(err => console.error('回答取得エラー', err));
+    });
 });

--- a/src/main/resources/static/js/quiz-answer-monitor.js
+++ b/src/main/resources/static/js/quiz-answer-monitor.js
@@ -6,31 +6,30 @@
  */
 
 document.addEventListener('DOMContentLoaded', () => {
-    const monitor = document.getElementById('quiz-answer-monitor');
-    if (!monitor) {
-        return;
-    }
-    const questionId = monitor.dataset.questionId;
-    if (!questionId) {
-        return;
-    }
+    const monitors = document.querySelectorAll('.quiz-answer-monitor');
+    monitors.forEach(monitor => {
+        const questionId = monitor.dataset.questionId;
+        if (!questionId) {
+            return;
+        }
 
-    fetch(`/api/quizzes/questions/${questionId}/answers`)
-        .then(response => response.json())
-        .then(data => {
-            const tbody = monitor.querySelector('tbody');
-            if (!tbody) {
-                return;
-            }
-            tbody.innerHTML = '';
-            data.forEach(row => {
-                const tr = document.createElement('tr');
-                tr.innerHTML = `
-                    <td>${row.studentName}</td>
-                    <td>${row.answerText ?? ''}</td>
-                    <td>${row.correct ? '○' : '×'}</td>`;
-                tbody.appendChild(tr);
-            });
-        })
-        .catch(err => console.error('回答取得エラー', err));
+        fetch(`/api/quizzes/questions/${questionId}/answers`)
+            .then(response => response.json())
+            .then(data => {
+                const tbody = monitor.querySelector('tbody');
+                if (!tbody) {
+                    return;
+                }
+                tbody.innerHTML = '';
+                data.forEach(row => {
+                    const tr = document.createElement('tr');
+                    tr.innerHTML = `
+                        <td>${row.studentName}</td>
+                        <td>${row.answerText ?? ''}</td>
+                        <td>${row.correct ? '○' : '×'}</td>`;
+                    tbody.appendChild(tr);
+                });
+            })
+            .catch(err => console.error('回答取得エラー', err));
+    });
 });

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -40,40 +40,6 @@
 
         <div class="container px-4 py-4">
             <input type="hidden" id="studentId" th:value="${studentId}">
-            <section id="quiz-answer-monitor" sec:authorize="hasRole('INSTRUCTOR')"
-                     class="bg-white rounded shadow p-4 mb-4"
-                     th:attr="data-question-id=${questionId}">
-                <h2 class="fw-bold text-primary mb-4">
-                    <i class="fas fa-users me-2"></i>回答モニタ
-                </h2>
-                <div class="table-responsive">
-                    <table class="table table-striped">
-                        <thead>
-                            <tr>
-                                <th>学生名</th>
-                                <th>回答</th>
-                                <th>正誤</th>
-                            </tr>
-                        </thead>
-                        <tbody></tbody>
-                    </table>
-                </div>
-            </section>
-            <section id="exercise-answer-monitor" sec:authorize="hasRole('INSTRUCTOR')"
-                     class="bg-white rounded shadow p-4 mb-4"
-                     th:attr="data-question-id=${questionId}">
-                <h2 class="fw-bold text-primary mb-4">
-                    <i class="fas fa-user-check me-2"></i>演習回答一覧
-                </h2>
-                <div class="row">
-                    <div class="col-md-4">
-                        <ul id="exercise-student-list" class="list-group"></ul>
-                    </div>
-                    <div class="col-md-8">
-                        <div id="exercise-answer-display" class="border rounded p-3">受講者を選択してください</div>
-                    </div>
-                </div>
-            </section>
             <!-- 学習目標セクション -->
             <section class="bg-white rounded shadow p-4 mb-4" th:if="${goals != null and !goals.isEmpty()}">
                 <h2 class="fw-bold text-primary mb-4">
@@ -204,6 +170,24 @@
                                 <p th:if="${quiz.explanation}" class="mt-0" th:utext="${quiz.explanation}">解説文</p>
                             </div>
                         </div>
+                        <div class="quiz-answer-monitor mt-3" sec:authorize="hasRole('INSTRUCTOR')"
+                             th:attr="data-question-id=${quiz.id}">
+                            <h5 class="fw-bold text-primary mb-2">
+                                <i class="fas fa-users me-2"></i>回答モニタ
+                            </h5>
+                            <div class="table-responsive">
+                                <table class="table table-striped">
+                                    <thead>
+                                        <tr>
+                                            <th>学生名</th>
+                                            <th>回答</th>
+                                            <th>正誤</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody></tbody>
+                                </table>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </section>
@@ -237,6 +221,20 @@
                             <h4 class="fw-semibold mb-2">回答例：</h4>
                             <p th:utext="${exercise.correctAnswer}">回答</p>
                             <p th:if="${exercise.explanation}" th:utext="${exercise.explanation}">解説</p>
+                        </div>
+                        <div class="exercise-answer-monitor mt-3" sec:authorize="hasRole('INSTRUCTOR')"
+                             th:attr="data-question-id=${exercise.id}">
+                            <h5 class="fw-bold text-primary mb-2">
+                                <i class="fas fa-user-check me-2"></i>演習回答一覧
+                            </h5>
+                            <div class="row">
+                                <div class="col-md-4">
+                                    <ul class="exercise-student-list list-group"></ul>
+                                </div>
+                                <div class="col-md-8">
+                                    <div class="exercise-answer-display border rounded p-3">受講者を選択してください</div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- クイズ・演習それぞれの問題に対応する回答モニタを追加し、従来の単一モニタを削除
- quiz/exercise 各モニタを複数要素として巡回し、`data-question-id` に基づく回答一覧を描画
- `questionId` モデル属性の不要化を明示

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68b7896f07888324ad88a4f40390ec36