### PR TITLE
Add quiz session context to answer submission

### DIFF
--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -1,4 +1,4 @@
-async function submitQuizAnswer(questionId) {
+async function submitQuizAnswer(quizId, questionId) {
     const studentInput = document.getElementById('studentId');
     const studentId = studentInput ? studentInput.value : null;
 
@@ -19,7 +19,7 @@ async function submitQuizAnswer(questionId) {
         const response = await fetch(`/api/quizzes/questions/${questionId}/answer`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ studentId: studentId, answer: answer })
+            body: JSON.stringify({ quizId, studentId, answer })
         });
         if (!response.ok) {
             throw new Error('Network response was not ok');

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -156,7 +156,7 @@
                             </li>
                         </ol>
                         <div class="mt-2">
-                            <button class="btn btn-success" th:onclick="'submitQuizAnswer(' + ${quiz.id} + ')'">回答送信</button>
+                            <button class="btn btn-success" th:onclick="'submitQuizAnswer(' + ${quizSessionId} + ', ' + ${quiz.id} + ')'">回答送信</button>
                             <div th:id="'quiz-result-' + ${quiz.id}" class="mt-2"></div>
                         </div>
                         <div sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')">


### PR DESCRIPTION
## Summary
- Pass quiz session ID and question ID from lecture template when submitting quiz answers
- Include quiz ID in answer submission payload and update handler signature

## Testing
- `./gradlew test`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b79650485c8324bcc8a66fa663e20e