### PR TITLE
Add refresh functions for answer monitors

### DIFF
--- a/src/main/resources/static/js/exercise-answer-monitor.js
+++ b/src/main/resources/static/js/exercise-answer-monitor.js
@@ -5,33 +5,41 @@
  * 作成日: 2025-09-02
  */
 
+function refreshExerciseAnswerMonitor(questionId) {
+    const monitor = document.querySelector(`.exercise-answer-monitor[data-question-id="${questionId}"]`);
+    if (!monitor) {
+        return;
+    }
+
+    fetch(`/api/question-banks/${questionId}/answers`)
+        .then(response => response.json())
+        .then(data => {
+            const list = monitor.querySelector('.exercise-student-list');
+            const display = monitor.querySelector('.exercise-answer-display');
+            if (!list || !display) {
+                return;
+            }
+            list.innerHTML = '';
+            display.textContent = '';
+            data.forEach(row => {
+                const li = document.createElement('li');
+                li.className = 'list-group-item list-group-item-action';
+                li.textContent = row.studentName;
+                li.addEventListener('click', () => {
+                    display.textContent = row.answerText ?? '';
+                });
+                list.appendChild(li);
+            });
+        })
+        .catch(err => console.error('回答取得エラー', err));
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     const monitors = document.querySelectorAll('.exercise-answer-monitor');
     monitors.forEach(monitor => {
         const questionId = monitor.dataset.questionId;
-        if (!questionId) {
-            return;
+        if (questionId) {
+            refreshExerciseAnswerMonitor(questionId);
         }
-
-        fetch(`/api/question-banks/${questionId}/answers`)
-            .then(response => response.json())
-            .then(data => {
-                const list = monitor.querySelector('.exercise-student-list');
-                const display = monitor.querySelector('.exercise-answer-display');
-                if (!list || !display) {
-                    return;
-                }
-                list.innerHTML = '';
-                data.forEach(row => {
-                    const li = document.createElement('li');
-                    li.className = 'list-group-item list-group-item-action';
-                    li.textContent = row.studentName;
-                    li.addEventListener('click', () => {
-                        display.textContent = row.answerText ?? '';
-                    });
-                    list.appendChild(li);
-                });
-            })
-            .catch(err => console.error('回答取得エラー', err));
     });
 });

--- a/src/main/resources/static/js/lecture-exercise.js
+++ b/src/main/resources/static/js/lecture-exercise.js
@@ -15,6 +15,7 @@ async function submitExerciseAnswer(questionId, lectureId, answerText) {
             resultEl.textContent = '回答を送信しました';
             resultEl.className = 'mt-2 text-success';
         }
+        refreshExerciseAnswerMonitor(questionId);
     } catch (error) {
         console.error('Failed to submit exercise answer', error);
         if (resultEl) {

--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -29,6 +29,7 @@ async function submitQuizAnswer(quizId, questionId) {
             resultEl.textContent = result.correct ? `正解！ ${result.explanation ?? ''}` : `不正解。${result.explanation ?? ''}`;
             resultEl.className = result.correct ? 'text-success' : 'text-danger';
         }
+        refreshQuizAnswerMonitor(questionId);
     } catch (error) {
         console.error('Failed to submit answer', error);
     }

--- a/src/main/resources/static/js/quiz-answer-monitor.js
+++ b/src/main/resources/static/js/quiz-answer-monitor.js
@@ -5,31 +5,38 @@
  * 作成日: 2025-09-02
  */
 
+function refreshQuizAnswerMonitor(questionId) {
+    const monitor = document.querySelector(`.quiz-answer-monitor[data-question-id="${questionId}"]`);
+    if (!monitor) {
+        return;
+    }
+
+    fetch(`/api/quizzes/questions/${questionId}/answers`)
+        .then(response => response.json())
+        .then(data => {
+            const tbody = monitor.querySelector('tbody');
+            if (!tbody) {
+                return;
+            }
+            tbody.innerHTML = '';
+            data.forEach(row => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${row.studentName}</td>
+                    <td>${row.answerText ?? ''}</td>
+                    <td>${row.correct ? '○' : '×'}</td>`;
+                tbody.appendChild(tr);
+            });
+        })
+        .catch(err => console.error('回答取得エラー', err));
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     const monitors = document.querySelectorAll('.quiz-answer-monitor');
     monitors.forEach(monitor => {
         const questionId = monitor.dataset.questionId;
-        if (!questionId) {
-            return;
+        if (questionId) {
+            refreshQuizAnswerMonitor(questionId);
         }
-
-        fetch(`/api/quizzes/questions/${questionId}/answers`)
-            .then(response => response.json())
-            .then(data => {
-                const tbody = monitor.querySelector('tbody');
-                if (!tbody) {
-                    return;
-                }
-                tbody.innerHTML = '';
-                data.forEach(row => {
-                    const tr = document.createElement('tr');
-                    tr.innerHTML = `
-                        <td>${row.studentName}</td>
-                        <td>${row.answerText ?? ''}</td>
-                        <td>${row.correct ? '○' : '×'}</td>`;
-                    tbody.appendChild(tr);
-                });
-            })
-            .catch(err => console.error('回答取得エラー', err));
     });
 });


### PR DESCRIPTION
## Summary
- add refreshQuizAnswerMonitor and refreshExerciseAnswerMonitor to reload answer lists
- refresh quiz and exercise monitors after submitting answers

## Testing
- `npm test` (fails: Missing script: "test")
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68b79799a278832496a85f8a603c1a58