### PR TITLE
quiz-answer-monitorでDOM操作にcreateElementを使用

### DIFF
--- a/src/main/resources/static/js/quiz-answer-monitor.js
+++ b/src/main/resources/static/js/quiz-answer-monitor.js
@@ -21,10 +21,19 @@ function refreshQuizAnswerMonitor(questionId) {
             tbody.innerHTML = '';
             data.forEach(row => {
                 const tr = document.createElement('tr');
-                tr.innerHTML = `
-                    <td>${row.studentName}</td>
-                    <td>${row.answerText ?? ''}</td>
-                    <td>${row.correct ? '○' : '×'}</td>`;
+
+                const studentTd = document.createElement('td');
+                studentTd.textContent = row.studentName;
+                tr.appendChild(studentTd);
+
+                const answerTd = document.createElement('td');
+                answerTd.textContent = row.answerText ?? '';
+                tr.appendChild(answerTd);
+
+                const correctTd = document.createElement('td');
+                correctTd.textContent = row.correct ? '○' : '×';
+                tr.appendChild(correctTd);
+
                 tbody.appendChild(tr);
             });
         })


### PR DESCRIPTION
## Summary
- replace `innerHTML` based row rendering with `createElement` and `textContent`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:e2e` *(fails: psql: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b7985fd6c88324a279f4d2e4381fc9