### PR TITLE
講義クイズで複数選択に対応

### DIFF
--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -13,7 +13,8 @@ async function submitQuizAnswer(quizId, questionId) {
         return;
     }
 
-    const answer = Array.from(selectedOptions).map(opt => opt.value).join(',');
+    // 選択肢を配列化し、複数選択（チェックボックス）でも回答を送信可能にする
+    const answer = Array.from(selectedOptions).map(option => option.value).join(',');
 
     try {
         const response = await fetch(`/api/quizzes/questions/${questionId}/answer`, {

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -137,22 +137,22 @@
                         <h4 class="fw-semibold mb-2" th:text="${quiz.questionNumber + '. ' + quiz.questionText}">問題文</h4>
                         <ol class="quiz-options ms-3">
                             <li th:if="${quiz.optionA}">
-                                <label><input type="radio" th:name="'quiz-' + ${quiz.id}" value="A"><span th:text="${#strings.substringAfter(quiz.optionA, '. ')}">選択肢A</span></label>
+                                <label><input th:attr="type=${quiz.questionType == 'MULTI' ? 'checkbox' : 'radio'}" th:name="'quiz-' + ${quiz.id}" value="A"><span th:text="${#strings.substringAfter(quiz.optionA, '. ')}">選択肢A</span></label>
                             </li>
                             <li th:if="${quiz.optionB}">
-                                <label><input type="radio" th:name="'quiz-' + ${quiz.id}" value="B"><span th:text="${#strings.substringAfter(quiz.optionB, '. ')}">選択肢B</span></label>
+                                <label><input th:attr="type=${quiz.questionType == 'MULTI' ? 'checkbox' : 'radio'}" th:name="'quiz-' + ${quiz.id}" value="B"><span th:text="${#strings.substringAfter(quiz.optionB, '. ')}">選択肢B</span></label>
                             </li>
                             <li th:if="${quiz.optionC}">
-                                <label><input type="radio" th:name="'quiz-' + ${quiz.id}" value="C"><span th:text="${#strings.substringAfter(quiz.optionC, '. ')}">選択肢C</span></label>
+                                <label><input th:attr="type=${quiz.questionType == 'MULTI' ? 'checkbox' : 'radio'}" th:name="'quiz-' + ${quiz.id}" value="C"><span th:text="${#strings.substringAfter(quiz.optionC, '. ')}">選択肢C</span></label>
                             </li>
                             <li th:if="${quiz.optionD}">
-                                <label><input type="radio" th:name="'quiz-' + ${quiz.id}" value="D"><span th:text="${#strings.substringAfter(quiz.optionD, '. ')}">選択肢D</span></label>
+                                <label><input th:attr="type=${quiz.questionType == 'MULTI' ? 'checkbox' : 'radio'}" th:name="'quiz-' + ${quiz.id}" value="D"><span th:text="${#strings.substringAfter(quiz.optionD, '. ')}">選択肢D</span></label>
                             </li>
                             <li th:if="${quiz.optionE}">
-                                <label><input type="radio" th:name="'quiz-' + ${quiz.id}" value="E"><span th:text="${#strings.substringAfter(quiz.optionE, '. ')}">選択肢E</span></label>
+                                <label><input th:attr="type=${quiz.questionType == 'MULTI' ? 'checkbox' : 'radio'}" th:name="'quiz-' + ${quiz.id}" value="E"><span th:text="${#strings.substringAfter(quiz.optionE, '. ')}">選択肢E</span></label>
                             </li>
                             <li th:if="${quiz.optionF}">
-                                <label><input type="radio" th:name="'quiz-' + ${quiz.id}" value="F"><span th:text="${#strings.substringAfter(quiz.optionF, '. ')}">選択肢F</span></label>
+                                <label><input th:attr="type=${quiz.questionType == 'MULTI' ? 'checkbox' : 'radio'}" th:name="'quiz-' + ${quiz.id}" value="F"><span th:text="${#strings.substringAfter(quiz.optionF, '. ')}">選択肢F</span></label>
                             </li>
                         </ol>
                         <div class="mt-2">


### PR DESCRIPTION
## Summary
- クイズの選択肢に対して `th:attr` を用いてラジオ/チェックボックスを動的に切り替え
- 複数選択された回答をカンマ区切りで送信できるようにクイズ送信処理を更新

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_68b798e397148324847172d055363e3d