### PR TITLE
fix: guard empty exercise answer submission

### DIFF
--- a/src/main/resources/static/js/lecture-exercise.js
+++ b/src/main/resources/static/js/lecture-exercise.js
@@ -2,6 +2,13 @@ async function submitExerciseAnswer(questionId, lectureId, answerText) {
     const studentInput = document.getElementById('studentId');
     const studentId = studentInput ? studentInput.value : null;
     const resultEl = document.getElementById(`exercise-result-${questionId}`);
+    if (!answerText || answerText.trim() === '') {
+        if (resultEl) {
+            resultEl.textContent = '回答を入力してください';
+            resultEl.className = 'mt-2 text-danger';
+        }
+        return;
+    }
     try {
         const response = await fetch(`/api/question-banks/${questionId}/answer`, {
             method: 'POST',


### PR DESCRIPTION
## Summary
- prevent submission when exercise answer text is empty

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b79abf96b48324afa567ef00453b04