### PR TITLE
Fix quiz answer submission IDs

### DIFF
--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -1,4 +1,4 @@
-async function submitQuizAnswer(quizId, questionId) {
+async function submitQuizAnswer(questionId) {
     const studentInput = document.getElementById('studentId');
     const studentId = studentInput ? studentInput.value : null;
 
@@ -20,7 +20,7 @@ async function submitQuizAnswer(quizId, questionId) {
         const response = await fetch(`/api/quizzes/questions/${questionId}/answer`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ quizId, studentId, answer })
+            body: JSON.stringify({ studentId, answer })
         });
         if (!response.ok) {
             throw new Error('Network response was not ok');

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -156,7 +156,7 @@
                             </li>
                         </ol>
                         <div class="mt-2">
-                            <button class="btn btn-success" th:onclick="'submitQuizAnswer(' + ${quizSessionId} + ', ' + ${quiz.id} + ')'">回答送信</button>
+                            <button class="btn btn-success" th:onclick="'submitQuizAnswer(' + ${quiz.id} + ')'">回答送信</button>
                             <div th:id="'quiz-result-' + ${quiz.id}" class="mt-2"></div>
                         </div>
                         <div sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')">


### PR DESCRIPTION
## Summary
- remove unused quizSessionId from lecture quiz submission
- send student answers using quiz question ID

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_b_68b7ab26aab0832481ab8d18bec2af64