### PR TITLE
Add CSRF token to fetch requests

### DIFF
--- a/src/main/resources/static/js/dashboard-answer.js
+++ b/src/main/resources/static/js/dashboard-answer.js
@@ -4,6 +4,15 @@
  * 作成日: 2025-09-03
  */
 
+function getCsrfToken() {
+    const meta = document.querySelector('meta[name="_csrf"]');
+    if (meta) {
+        return meta.getAttribute('content');
+    }
+    const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : null;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('answer-form');
     const quizIdInput = document.getElementById('quiz-id');
@@ -47,9 +56,14 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         try {
+            const csrfToken = getCsrfToken();
+            const headers = { 'Content-Type': 'application/json' };
+            if (csrfToken) {
+                headers['X-CSRF-TOKEN'] = csrfToken;
+            }
             const response = await fetch(`/api/quizzes/${quizId}/answer`, {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
+                headers: headers,
                 body: JSON.stringify({ [questionId]: answerText })
             });
 

--- a/src/main/resources/static/js/lecture-exercise.js
+++ b/src/main/resources/static/js/lecture-exercise.js
@@ -1,3 +1,12 @@
+function getCsrfToken() {
+    const meta = document.querySelector('meta[name="_csrf"]');
+    if (meta) {
+        return meta.getAttribute('content');
+    }
+    const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : null;
+}
+
 async function submitExerciseAnswer(questionId, lectureId, answerText) {
     const studentInput = document.getElementById('studentId');
     const studentId = studentInput ? studentInput.value : null;
@@ -10,9 +19,14 @@ async function submitExerciseAnswer(questionId, lectureId, answerText) {
         return;
     }
     try {
+        const csrfToken = getCsrfToken();
+        const headers = { 'Content-Type': 'application/json' };
+        if (csrfToken) {
+            headers['X-CSRF-TOKEN'] = csrfToken;
+        }
         const response = await fetch(`/api/question-banks/${questionId}/answer`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: headers,
             body: JSON.stringify({ lectureId: lectureId, studentId: studentId, answerText: answerText })
         });
         if (!response.ok) {

--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -1,3 +1,12 @@
+function getCsrfToken() {
+    const meta = document.querySelector('meta[name="_csrf"]');
+    if (meta) {
+        return meta.getAttribute('content');
+    }
+    const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : null;
+}
+
 async function submitQuizAnswer(questionId) {
     const studentInput = document.getElementById('studentId');
     const studentId = studentInput ? studentInput.value : null;
@@ -17,9 +26,14 @@ async function submitQuizAnswer(questionId) {
     const answer = Array.from(selectedOptions).map(option => option.value).join(',');
 
     try {
+        const csrfToken = getCsrfToken();
+        const headers = { 'Content-Type': 'application/json' };
+        if (csrfToken) {
+            headers['X-CSRF-TOKEN'] = csrfToken;
+        }
         const response = await fetch(`/api/quizzes/questions/${questionId}/answer`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: headers,
             body: JSON.stringify({ studentId, answer })
         });
         if (!response.ok) {


### PR DESCRIPTION
## Summary
- attach CSRF token from meta or cookies to lecture quiz answer requests
- secure exercise answer submissions with CSRF header
- include CSRF token in dashboard answer posts

## Testing
- `./gradlew test`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b7ac5637d88324940418f77a6fd53d