### PR TITLE
回答モニタのデフォルト文言追加

### DIFF
--- a/src/main/resources/static/js/exercise-answer-monitor.js
+++ b/src/main/resources/static/js/exercise-answer-monitor.js
@@ -20,13 +20,15 @@ function refreshExerciseAnswerMonitor(questionId) {
                 return;
             }
             list.innerHTML = '';
-            display.textContent = '';
+            display.textContent = '受講者を選択してください';
             data.forEach(row => {
                 const li = document.createElement('li');
                 li.className = 'list-group-item list-group-item-action';
                 li.textContent = row.studentName;
                 li.addEventListener('click', () => {
-                    display.textContent = row.answerText ?? '';
+                    display.textContent = row.answerText && row.answerText.trim() !== ''
+                        ? row.answerText
+                        : '受講者を選択してください';
                 });
                 list.appendChild(li);
             });


### PR DESCRIPTION
## Summary
- 回答モニタで初期表示と空回答時に"受講者を選択してください"を表示

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68b7b01b56388324807310549c70239c