### PR TITLE
Sanitize lecture content and escape exercise text

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3'
     implementation 'org.apache.commons:commons-collections4:4.4'
     implementation 'commons-io:commons-io:2.11.0'
+    implementation 'org.jsoup:jsoup:1.16.1'
 
     // Object Mapping
     implementation 'com.github.dozermapper:dozer-core:6.5.2'

--- a/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
@@ -35,6 +35,8 @@ import jp.co.apsa.giiku.service.WeekService;
 import jp.co.apsa.giiku.service.QuizQuestionBankService;
 import jp.co.apsa.giiku.service.QuestionBankService;
 import jp.co.apsa.giiku.domain.entity.QuestionBank;
+import org.jsoup.Jsoup;
+import org.jsoup.safety.Safelist;
 
 /**
  * 講義詳細ページを表示するコントローラー。
@@ -120,6 +122,11 @@ public class LectureViewController extends AbstractController {
         Map<Long, List<LectureContentBlock>> chapterContentBlocks = new HashMap<>();
         for (Chapter chapter : chapters) {
             List<LectureContentBlock> blocks = lectureContentBlockService.findByChapterIdOrderBySortOrder(chapter.getId());
+            for (LectureContentBlock block : blocks) {
+                if (block.getContent() != null) {
+                    block.setContent(Jsoup.clean(block.getContent(), Safelist.basic()));
+                }
+            }
             chapterContentBlocks.put(chapter.getId(), blocks);
         }
         model.addAttribute("chapterContentBlocks", chapterContentBlocks);

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -167,7 +167,7 @@
                             </button>
                             <div th:id="'quiz-answer' + ${quizStat.count}" class="answer-content">
                                 <h4 class="fw-semibold mb-2">正解：<span class="text-danger" th:text="${quiz.correctAnswer}">1</span></h4>
-                                <p th:if="${quiz.explanation}" class="mt-0" th:utext="${quiz.explanation}">解説文</p>
+                                <p th:if="${quiz.explanation}" class="mt-0" th:text="${quiz.explanation}">解説文</p>
                             </div>
                         </div>
                         <div class="quiz-answer-monitor mt-3" sec:authorize="hasRole('INSTRUCTOR')"
@@ -201,7 +201,7 @@
                     <h3 class="fw-semibold mb-3" th:text="${chapter.chapterNumber + '. ' + chapter.title}"></h3>
                     <div th:each="exercise, exStat : ${exercisesByChapter[chapter.id]}" class="border rounded p-4 mb-4">
                         <h4 class="fw-bold text-primary mb-3" th:text="${'演習問題' + exercise.questionNumber}">演習問題タイトル</h4>
-                        <p class="mb-3" th:utext="${exercise.questionText}">問題説明</p>
+                        <p class="mb-3" th:text="${exercise.questionText}">問題説明</p>
                         <div class="mb-3">
                             <textarea class="form-control" th:id="|exercise-input-${exercise.id}|" rows="3" placeholder="回答を入力してください"></textarea>
                         </div>
@@ -219,8 +219,8 @@
                              th:id="'exercise-answer' + ${exStat.count}"
                              class="answer-content">
                             <h4 class="fw-semibold mb-2">回答例：</h4>
-                            <p th:utext="${exercise.correctAnswer}">回答</p>
-                            <p th:if="${exercise.explanation}" th:utext="${exercise.explanation}">解説</p>
+                            <p th:text="${exercise.correctAnswer}">回答</p>
+                            <p th:if="${exercise.explanation}" th:text="${exercise.explanation}">解説</p>
                         </div>
                         <div class="exercise-answer-monitor mt-3" sec:authorize="hasRole('INSTRUCTOR')"
                              th:attr="data-question-id=${exercise.id}">


### PR DESCRIPTION
## Summary
- escape quiz and exercise texts with `th:text`
- sanitize chapter content blocks server-side using Jsoup
- add Jsoup dependency

## Testing
- `./gradlew test`
- `npm run test:e2e` *(fails: psql not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b7b1b285a08324957efaaddc7bfeb1