### PR TITLE
クイズ回答送信でクイズIDを含めるよう修正

### DIFF
--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -7,7 +7,7 @@ function getCsrfToken() {
     return match ? decodeURIComponent(match[1]) : null;
 }
 
-async function submitQuizAnswer(questionId) {
+async function submitQuizAnswer(quizId, questionId) {
     const studentInput = document.getElementById('studentId');
     const studentId = studentInput ? studentInput.value : null;
 
@@ -34,7 +34,7 @@ async function submitQuizAnswer(questionId) {
         const response = await fetch(`/api/quizzes/questions/${questionId}/answer`, {
             method: 'POST',
             headers: headers,
-            body: JSON.stringify({ studentId, answer })
+            body: JSON.stringify({ quizId, studentId, answer })
         });
         if (!response.ok) {
             throw new Error('Network response was not ok');

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -156,7 +156,7 @@
                             </li>
                         </ol>
                         <div class="mt-2">
-                            <button class="btn btn-success" th:onclick="'submitQuizAnswer(' + ${quiz.id} + ')'">回答送信</button>
+                            <button class="btn btn-success" th:onclick="|submitQuizAnswer(${quiz.id}, ${quiz.id})|">回答送信</button>
                             <div th:id="'quiz-result-' + ${quiz.id}" class="mt-2"></div>
                         </div>
                         <div sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')">


### PR DESCRIPTION
## Summary
- 理解度テストの回答ボタンからクイズIDと問題IDを送信
- `submitQuizAnswer` がクイズIDを受け取り、リクエストに含めるよう更新

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_b_68b7be2f32948324b45b9ae2ebfeafb7