### PR TITLE
CSRF トークン取得処理のモジュール化

### DIFF
--- a/src/main/resources/static/js/csrf.js
+++ b/src/main/resources/static/js/csrf.js
@@ -1,0 +1,8 @@
+export function getCsrfToken() {
+    const meta = document.querySelector('meta[name="_csrf"]');
+    if (meta) {
+        return meta.getAttribute('content');
+    }
+    const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : null;
+}

--- a/src/main/resources/static/js/dashboard-answer.js
+++ b/src/main/resources/static/js/dashboard-answer.js
@@ -4,14 +4,7 @@
  * 作成日: 2025-09-03
  */
 
-function getCsrfToken() {
-    const meta = document.querySelector('meta[name="_csrf"]');
-    if (meta) {
-        return meta.getAttribute('content');
-    }
-    const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
-    return match ? decodeURIComponent(match[1]) : null;
-}
+import { getCsrfToken } from './csrf.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     const form = document.getElementById('answer-form');

--- a/src/main/resources/static/js/lecture-exercise.js
+++ b/src/main/resources/static/js/lecture-exercise.js
@@ -1,11 +1,4 @@
-function getCsrfToken() {
-    const meta = document.querySelector('meta[name="_csrf"]');
-    if (meta) {
-        return meta.getAttribute('content');
-    }
-    const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
-    return match ? decodeURIComponent(match[1]) : null;
-}
+import { getCsrfToken } from './csrf.js';
 
 async function submitExerciseAnswer(questionId, lectureId, answerText) {
     const studentInput = document.getElementById('studentId');

--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -1,11 +1,4 @@
-function getCsrfToken() {
-    const meta = document.querySelector('meta[name="_csrf"]');
-    if (meta) {
-        return meta.getAttribute('content');
-    }
-    const match = document.cookie.match(/XSRF-TOKEN=([^;]+)/);
-    return match ? decodeURIComponent(match[1]) : null;
-}
+import { getCsrfToken } from './csrf.js';
 
 async function submitQuizAnswer(quizId, questionId) {
     const studentInput = document.getElementById('studentId');


### PR DESCRIPTION
## Summary
- 共有モジュール csrf.js を追加し CSRF トークン取得を共通化
- lecture-quiz.js / lecture-exercise.js / dashboard-answer.js から重複コードを削除しモジュールをインポート

## Testing
- `npm test` (script 未定義)
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68b7c075bd04832484d8ac9e1447e45f