### PR TITLE
クイズ送信失敗時のエラーメッセージを追加

### DIFF
--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -39,6 +39,10 @@ async function submitQuizAnswer(quizId, questionId) {
         }
         refreshQuizAnswerMonitor(questionId);
     } catch (error) {
+        if (resultEl) {
+            resultEl.textContent = '送信に失敗しました';
+            resultEl.className = 'text-danger';
+        }
         console.error('Failed to submit answer', error);
     }
 }


### PR DESCRIPTION
## Summary
- クイズ回答送信の失敗時にエラーメッセージを表示

## Testing
- `npm run test:e2e` (psql not found)
- `./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_b_68b7c3b8ad408324abd656ebfaf880e6