### PR TITLE
演習回答モニタの未回答表示を修正

### DIFF
--- a/src/main/resources/static/js/exercise-answer-monitor.js
+++ b/src/main/resources/static/js/exercise-answer-monitor.js
@@ -28,7 +28,7 @@ function refreshExerciseAnswerMonitor(questionId) {
                 li.addEventListener('click', () => {
                     display.textContent = row.answerText && row.answerText.trim() !== ''
                         ? row.answerText
-                        : '受講者を選択してください';
+                        : '回答なし';
                 });
                 list.appendChild(li);
             });


### PR DESCRIPTION
## Summary
- 演習回答一覧で受講者をクリックした際、未回答の場合は「回答なし」と表示するよう変更
- 初期表示のメッセージは従来通り「受講者を選択してください」と維持

## Testing
- `npm test` *(missing script: "test")*
- `npm run test:e2e` *(psql: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b7c9926aa483248eaf9b8c396d196c