### PR TITLE
講義関連クラスにJavadocタグを追加

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/domain/repository/LectureContentBlockRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/LectureContentBlockRepository.java
@@ -7,7 +7,13 @@ import java.util.List;
 
 import jp.co.apsa.giiku.domain.entity.LectureContentBlock;
 
-
+/**
+ * 講義コンテンツブロックのリポジトリインターフェース.
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
 @Repository
 public interface LectureContentBlockRepository extends JpaRepository<LectureContentBlock, Long> {
     

--- a/src/main/java/jp/co/apsa/giiku/domain/repository/LectureGoalRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/LectureGoalRepository.java
@@ -7,6 +7,13 @@ import java.util.List;
 
 import jp.co.apsa.giiku.domain.entity.LectureGoal;
 
+/**
+ * 講義目標のリポジトリインターフェース.
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
 @Repository
 public interface LectureGoalRepository extends JpaRepository<LectureGoal, Long> {
     

--- a/src/main/java/jp/co/apsa/giiku/service/LectureContentBlockService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/LectureContentBlockService.java
@@ -9,6 +9,13 @@ import java.util.List;
 import jp.co.apsa.giiku.domain.entity.LectureContentBlock;
 import jp.co.apsa.giiku.domain.repository.LectureContentBlockRepository;
 
+/**
+ * 講義コンテンツブロックに関するサービスクラス.
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
 @Service
 @Transactional
 public class LectureContentBlockService {

--- a/src/main/java/jp/co/apsa/giiku/service/LectureGoalService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/LectureGoalService.java
@@ -9,6 +9,13 @@ import java.util.List;
 import jp.co.apsa.giiku.domain.entity.LectureGoal;
 import jp.co.apsa.giiku.domain.repository.LectureGoalRepository;
 
+/**
+ * 講義目標に関するサービスクラス.
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
 @Service
 @Transactional
 public class LectureGoalService {


### PR DESCRIPTION
## Summary
- 講義関連のリポジトリとサービスに著者・バージョン・sinceタグを追加

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68b7cea055a08324acca9b20e8f9e156