### PR TITLE
Use DTO for quiz answer validation

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/controller/QuizController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/QuizController.java
@@ -17,8 +17,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.validation.BindingResult;
 
 import jakarta.validation.Valid;
+import jp.co.apsa.giiku.dto.QuizAnswerRequest;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
@@ -193,16 +195,21 @@ public class QuizController extends AbstractController {
      * 個別のクイズ回答を受け付け判定します。
      *
      * @param questionId 質問ID
-     * @param payload    回答情報（quizId, studentId, answer）
+     * @param request    回答情報（quizId, studentId, answer）
      * @return 判定結果
      */
     @PostMapping("/questions/{questionId}/answer")
     public ResponseEntity<Map<String, Object>> answerQuestion(@PathVariable Long questionId,
-                                                              @RequestBody Map<String, String> payload) {
+                                                              @Valid @RequestBody QuizAnswerRequest request,
+                                                              BindingResult bindingResult) {
         try {
-            Long quizId = payload.get("quizId") != null ? Long.parseLong(payload.get("quizId")) : null;
-            Long studentId = payload.get("studentId") != null ? Long.parseLong(payload.get("studentId")) : null;
-            String answer = payload.get("answer");
+            if (bindingResult.hasErrors()) {
+                return ResponseEntity.badRequest().build();
+            }
+
+            Long quizId = request.getQuizId();
+            Long studentId = request.getStudentId();
+            String answer = request.getAnswer();
 
             QuizQuestionBank question = quizQuestionBankRepository.findById(questionId)
                     .orElseThrow();

--- a/src/main/java/jp/co/apsa/giiku/dto/QuizAnswerRequest.java
+++ b/src/main/java/jp/co/apsa/giiku/dto/QuizAnswerRequest.java
@@ -1,0 +1,74 @@
+package jp.co.apsa.giiku.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * クイズ回答リクエスト用DTOクラス
+ *
+ * @author 株式会社アプサ
+ * @version 1.0
+ * @since 2025
+ */
+public class QuizAnswerRequest {
+
+    @NotNull(message = "クイズIDは必須です")
+    private Long quizId;
+
+    @NotNull(message = "学生IDは必須です")
+    private Long studentId;
+
+    @NotBlank(message = "回答は必須です")
+    private String answer;
+
+    /** QuizAnswerRequest メソッド */
+    public QuizAnswerRequest() {}
+
+    /** QuizAnswerRequest メソッド */
+    public QuizAnswerRequest(Long quizId, Long studentId, String answer) {
+        this.quizId = quizId;
+        this.studentId = studentId;
+        this.answer = answer;
+    }
+
+    /** getQuizId メソッド */
+    public Long getQuizId() {
+        return quizId;
+    }
+
+    /** setQuizId メソッド */
+    public void setQuizId(Long quizId) {
+        this.quizId = quizId;
+    }
+
+    /** getStudentId メソッド */
+    public Long getStudentId() {
+        return studentId;
+    }
+
+    /** setStudentId メソッド */
+    public void setStudentId(Long studentId) {
+        this.studentId = studentId;
+    }
+
+    /** getAnswer メソッド */
+    public String getAnswer() {
+        return answer;
+    }
+
+    /** setAnswer メソッド */
+    public void setAnswer(String answer) {
+        this.answer = answer;
+    }
+
+    /** toString メソッド */
+    @Override
+    public String toString() {
+        return "QuizAnswerRequest{" +
+                "quizId=" + quizId +
+                ", studentId=" + studentId +
+                ", answer='" + answer + '\'' +
+                '}';
+    }
+}
+


### PR DESCRIPTION
## Summary
- Map quiz answer payload to `QuizAnswerRequest` DTO and add field validation
- Validate quiz answer requests in `QuizController` and return bad request on missing fields

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68b7d12ac11c8324acb025c40a3172ea