### PR TITLE
script タグに type="module" を付与

### DIFF
--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -438,7 +438,7 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="/webjars/sockjs-client/sockjs.min.js" th:src="@{/webjars/sockjs-client/sockjs.min.js}"></script>
 <script src="/webjars/stomp-websocket/stomp.min.js" th:src="@{/webjars/stomp-websocket/stomp.min.js}"></script>
-<script src="../static/js/dashboard-answer.js" th:src="@{/js/dashboard-answer.js}"></script>
+<script src="../static/js/dashboard-answer.js" th:src="@{/js/dashboard-answer.js}" type="module"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         const ctx = document.getElementById('heroChart');

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -341,8 +341,8 @@
     <script th:src="@{/webjars/prismjs/1.29.0/prism.min.js}"></script>
     <script th:src="@{/webjars/prismjs/1.29.0/components/prism-java.min.js}"></script>
     <script th:src="@{/webjars/prismjs/1.29.0/components/prism-sql.min.js}"></script>
-    <script th:src="@{/js/lecture-quiz.js}"></script>
-    <script th:src='@{/js/lecture-exercise.js}'></script>
+    <script th:src="@{/js/lecture-quiz.js}" type="module"></script>
+    <script th:src='@{/js/lecture-exercise.js}' type="module"></script>
     <script th:src="@{/js/quiz-answer-monitor.js}"></script>
     <script th:src="@{/js/exercise-answer-monitor.js}"></script>
 </section>


### PR DESCRIPTION
## Summary
- lecture と dashboard のスクリプトを ES Modules として読み込むよう更新

## Testing
- `npm test` (Missing script: "test")
- `xdg-open src/main/resources/templates/index.html` (command not found)


------
https://chatgpt.com/codex/tasks/task_b_68b7d52af9008324877b59add1883f6c