### PR TITLE
モニタ用JSのHTTPエラーハンドリング追加

### DIFF
--- a/src/main/resources/static/js/exercise-answer-monitor.js
+++ b/src/main/resources/static/js/exercise-answer-monitor.js
@@ -12,7 +12,12 @@ function refreshExerciseAnswerMonitor(questionId) {
     }
 
     fetch(`/api/question-banks/${questionId}/answers`)
-        .then(response => response.json())
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('HTTP error');
+            }
+            return response.json();
+        })
         .then(data => {
             const list = monitor.querySelector('.exercise-student-list');
             const display = monitor.querySelector('.exercise-answer-display');
@@ -33,7 +38,13 @@ function refreshExerciseAnswerMonitor(questionId) {
                 list.appendChild(li);
             });
         })
-        .catch(err => console.error('回答取得エラー', err));
+        .catch(err => {
+            console.error('回答取得エラー', err);
+            const display = monitor.querySelector('.exercise-answer-display');
+            if (display) {
+                display.textContent = '取得に失敗しました';
+            }
+        });
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/src/main/resources/static/js/quiz-answer-monitor.js
+++ b/src/main/resources/static/js/quiz-answer-monitor.js
@@ -12,7 +12,12 @@ function refreshQuizAnswerMonitor(questionId) {
     }
 
     fetch(`/api/quizzes/questions/${questionId}/answers`)
-        .then(response => response.json())
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('HTTP error');
+            }
+            return response.json();
+        })
         .then(data => {
             const tbody = monitor.querySelector('tbody');
             if (!tbody) {
@@ -37,7 +42,13 @@ function refreshQuizAnswerMonitor(questionId) {
                 tbody.appendChild(tr);
             });
         })
-        .catch(err => console.error('回答取得エラー', err));
+        .catch(err => {
+            console.error('回答取得エラー', err);
+            const tbody = monitor.querySelector('tbody');
+            if (tbody) {
+                tbody.innerHTML = '<tr><td colspan="3">取得に失敗しました</td></tr>';
+            }
+        });
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- 演習・クイズ回答モニタでfetchのHTTPエラーを検知
- 取得失敗時にモニタ領域へエラーメッセージを表示

## Testing
- `npm run test:e2e` (psql: not found)


------
https://chatgpt.com/codex/tasks/task_b_68b7d88a0f1c8324821825a5c171d27b