### PR TITLE
refactor: use classList for status classes

### DIFF
--- a/src/main/resources/static/js/dashboard-answer.js
+++ b/src/main/resources/static/js/dashboard-answer.js
@@ -30,7 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
         feedEl.innerHTML = '';
         Object.keys(answers).forEach(questionId => {
             const li = document.createElement('li');
-            li.className = 'list-group-item';
+            li.classList.add('list-group-item');
             li.textContent = `Q${questionId}: ${answers[questionId]}`;
             feedEl.appendChild(li);
         });
@@ -44,7 +44,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (!quizId || !questionId) {
             statusEl.textContent = 'クイズIDと問題IDを入力してください。';
-            statusEl.className = 'text-danger';
+            statusEl.classList.remove('text-success', 'text-danger');
+            statusEl.classList.add('text-danger');
             return;
         }
 
@@ -62,17 +63,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (response.ok) {
                 statusEl.textContent = '送信が完了しました。';
-                statusEl.className = 'text-success';
+                statusEl.classList.remove('text-success', 'text-danger');
+                statusEl.classList.add('text-success');
                 if (!stompClient) {
                     connect(quizId);
                 }
             } else {
                 statusEl.textContent = '送信に失敗しました。';
-                statusEl.className = 'text-danger';
+                statusEl.classList.remove('text-success', 'text-danger');
+                statusEl.classList.add('text-danger');
             }
         } catch (error) {
             statusEl.textContent = '送信中にエラーが発生しました。';
-            statusEl.className = 'text-danger';
+            statusEl.classList.remove('text-success', 'text-danger');
+            statusEl.classList.add('text-danger');
         }
     });
 });

--- a/src/main/resources/static/js/lecture-exercise.js
+++ b/src/main/resources/static/js/lecture-exercise.js
@@ -7,7 +7,8 @@ async function submitExerciseAnswer(questionId, lectureId, answerText) {
     if (!answerText || answerText.trim() === '') {
         if (resultEl) {
             resultEl.textContent = '回答を入力してください';
-            resultEl.className = 'mt-2 text-danger';
+            resultEl.classList.remove('text-success', 'text-danger');
+            resultEl.classList.add('text-danger');
         }
         return;
     }
@@ -27,14 +28,16 @@ async function submitExerciseAnswer(questionId, lectureId, answerText) {
         }
         if (resultEl) {
             resultEl.textContent = '回答を送信しました';
-            resultEl.className = 'mt-2 text-success';
+            resultEl.classList.remove('text-success', 'text-danger');
+            resultEl.classList.add('text-success');
         }
         refreshExerciseAnswerMonitor(questionId);
     } catch (error) {
         console.error('Failed to submit exercise answer', error);
         if (resultEl) {
             resultEl.textContent = '送信に失敗しました';
-            resultEl.className = 'mt-2 text-danger';
+            resultEl.classList.remove('text-success', 'text-danger');
+            resultEl.classList.add('text-danger');
         }
     }
 }

--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -10,7 +10,8 @@ async function submitQuizAnswer(quizId, questionId) {
     if (!selectedOptions.length) {
         if (resultEl) {
             resultEl.textContent = '回答を選択してください。';
-            resultEl.className = 'text-danger';
+            resultEl.classList.remove('text-success', 'text-danger');
+            resultEl.classList.add('text-danger');
         }
         return;
     }
@@ -35,13 +36,15 @@ async function submitQuizAnswer(quizId, questionId) {
         const result = await response.json();
         if (resultEl) {
             resultEl.textContent = result.correct ? `正解！ ${result.explanation ?? ''}` : `不正解。${result.explanation ?? ''}`;
-            resultEl.className = result.correct ? 'text-success' : 'text-danger';
+            resultEl.classList.remove('text-success', 'text-danger');
+            resultEl.classList.add(result.correct ? 'text-success' : 'text-danger');
         }
         refreshQuizAnswerMonitor(questionId);
     } catch (error) {
         if (resultEl) {
             resultEl.textContent = '送信に失敗しました';
-            resultEl.className = 'text-danger';
+            resultEl.classList.remove('text-success', 'text-danger');
+            resultEl.classList.add('text-danger');
         }
         console.error('Failed to submit answer', error);
     }


### PR DESCRIPTION
## Summary
- replace className assignments with classList operations in dashboard, lecture quiz, and lecture exercise scripts

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b7d975a64883248d890a172351fab4