### PR TITLE
studentId未取得時の送信抑止と空回答チェックを追加

### DIFF
--- a/src/main/resources/static/js/dashboard-answer.js
+++ b/src/main/resources/static/js/dashboard-answer.js
@@ -49,6 +49,13 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
         }
 
+        if (!answerText) {
+            statusEl.textContent = '回答を入力してください。';
+            statusEl.classList.remove('text-success', 'text-danger');
+            statusEl.classList.add('text-danger');
+            return;
+        }
+
         try {
             const csrfToken = getCsrfToken();
             const headers = { 'Content-Type': 'application/json' };

--- a/src/main/resources/static/js/lecture-exercise.js
+++ b/src/main/resources/static/js/lecture-exercise.js
@@ -4,6 +4,14 @@ async function submitExerciseAnswer(questionId, lectureId, answerText) {
     const studentInput = document.getElementById('studentId');
     const studentId = studentInput ? studentInput.value : null;
     const resultEl = document.getElementById(`exercise-result-${questionId}`);
+    if (!studentId) {
+        if (resultEl) {
+            resultEl.textContent = '受講者IDを取得できませんでした。';
+            resultEl.classList.remove('text-success', 'text-danger');
+            resultEl.classList.add('text-danger');
+        }
+        return;
+    }
     if (!answerText || answerText.trim() === '') {
         if (resultEl) {
             resultEl.textContent = '回答を入力してください';

--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -7,6 +7,15 @@ async function submitQuizAnswer(quizId, questionId) {
     const selectedOptions = document.querySelectorAll(`input[name="quiz-${questionId}"]:checked`);
     const resultEl = document.getElementById(`quiz-result-${questionId}`);
 
+    if (!studentId) {
+        if (resultEl) {
+            resultEl.textContent = '受講者IDを取得できませんでした。';
+            resultEl.classList.remove('text-success', 'text-danger');
+            resultEl.classList.add('text-danger');
+        }
+        return;
+    }
+
     if (!selectedOptions.length) {
         if (resultEl) {
             resultEl.textContent = '回答を選択してください。';


### PR DESCRIPTION
## Summary
- studentId が取得できない場合にクイズ・演習の回答送信を中止しエラー表示
- ダッシュボードの回答フォームで空の回答を警告

## Testing
- `npm run test:e2e` (DB 接続エラーにより失敗)


------
https://chatgpt.com/codex/tasks/task_b_68b7db9ced5c832492cd2917d06ed8bf