### PR TITLE
Return 404 when quiz or question not found

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/controller/QuizController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/QuizController.java
@@ -171,7 +171,10 @@ public class QuizController extends AbstractController {
                                           @RequestBody Map<String, Object> answers) {
         try {
             logger.debug("クイズ回答保存リクエスト: id={}", id);
-            Quiz quiz = quizService.findById(id).orElseThrow();
+            Quiz quiz = quizService.findById(id).orElse(null);
+            if (quiz == null) {
+                return ResponseEntity.notFound().build();
+            }
             Long studentId = quiz.getStudentId();
 
             if (answers != null) {
@@ -212,7 +215,10 @@ public class QuizController extends AbstractController {
             String answer = request.getAnswer();
 
             QuizQuestionBank question = quizQuestionBankRepository.findById(questionId)
-                    .orElseThrow();
+                    .orElse(null);
+            if (question == null) {
+                return ResponseEntity.notFound().build();
+            }
 
             boolean correct = question.getCorrectAnswer() != null
                     && question.getCorrectAnswer().trim().equalsIgnoreCase(answer != null ? answer.trim() : "");


### PR DESCRIPTION
## Summary
- Handle missing quiz when saving answers
- Return 404 for unknown quiz question

## Testing
- `./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_b_68b7e023f6ec83249035ed195a8422cb