### PR TITLE
feat: モニタースクリプトをESモジュール化

### DIFF
--- a/src/main/resources/static/js/exercise-answer-monitor.js
+++ b/src/main/resources/static/js/exercise-answer-monitor.js
@@ -5,7 +5,7 @@
  * 作成日: 2025-09-02
  */
 
-function refreshExerciseAnswerMonitor(questionId) {
+export function refreshExerciseAnswerMonitor(questionId) {
     const monitor = document.querySelector(`.exercise-answer-monitor[data-question-id="${questionId}"]`);
     if (!monitor) {
         return;

--- a/src/main/resources/static/js/lecture-exercise.js
+++ b/src/main/resources/static/js/lecture-exercise.js
@@ -1,4 +1,5 @@
 import { getCsrfToken } from './csrf.js';
+import { refreshExerciseAnswerMonitor } from './exercise-answer-monitor.js';
 
 async function submitExerciseAnswer(questionId, lectureId, answerText) {
     const studentInput = document.getElementById('studentId');

--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -1,4 +1,5 @@
 import { getCsrfToken } from './csrf.js';
+import { refreshQuizAnswerMonitor } from './quiz-answer-monitor.js';
 
 async function submitQuizAnswer(quizId, questionId) {
     const studentInput = document.getElementById('studentId');

--- a/src/main/resources/static/js/quiz-answer-monitor.js
+++ b/src/main/resources/static/js/quiz-answer-monitor.js
@@ -5,7 +5,7 @@
  * 作成日: 2025-09-02
  */
 
-function refreshQuizAnswerMonitor(questionId) {
+export function refreshQuizAnswerMonitor(questionId) {
     const monitor = document.querySelector(`.quiz-answer-monitor[data-question-id="${questionId}"]`);
     if (!monitor) {
         return;

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -343,8 +343,8 @@
     <script th:src="@{/webjars/prismjs/1.29.0/components/prism-sql.min.js}"></script>
     <script th:src="@{/js/lecture-quiz.js}" type="module"></script>
     <script th:src='@{/js/lecture-exercise.js}' type="module"></script>
-    <script th:src="@{/js/quiz-answer-monitor.js}"></script>
-    <script th:src="@{/js/exercise-answer-monitor.js}"></script>
+    <script th:src="@{/js/quiz-answer-monitor.js}" type="module"></script>
+    <script th:src="@{/js/exercise-answer-monitor.js}" type="module"></script>
 </section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- `quiz-answer-monitor.js` と `exercise-answer-monitor.js` を ES モジュール化し、`refresh*` 関数をエクスポート
- 講義用スクリプトから各モニタをインポートするよう調整
- `lecture.html` の関連 `<script>` をモジュールとして読み込むよう更新

## Testing
- `npm test` *(失敗: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b7e37ff60483248b3f4468f65810b1