### PR TITLE
Use HashMap for quiz answer response

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/controller/QuizController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/QuizController.java
@@ -225,10 +225,9 @@ public class QuizController extends AbstractController {
 
             studentAnswerService.saveAnswer(quizId, questionId, studentId, answer);
 
-            Map<String, Object> response = Map.of(
-                    "correct", correct,
-                    "explanation", question.getExplanation()
-            );
+            Map<String, Object> response = new HashMap<>();
+            response.put("correct", correct);
+            response.put("explanation", question.getExplanation());
             return ResponseEntity.ok(response);
         } catch (Exception e) {
             logger.error("クイズ回答処理エラー: questionId={}", questionId, e);


### PR DESCRIPTION
## Summary
- Replace `Map.of` with a mutable `HashMap` in `QuizController` when building the response for an answered question

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_68b7e43b7d0083248f33bf746670df12