### PR TITLE
refactor: classList を利用したクラス操作

### DIFF
--- a/src/main/resources/static/js/answer-monitor.js
+++ b/src/main/resources/static/js/answer-monitor.js
@@ -31,7 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
         answersList.innerHTML = '';
         Object.keys(answers).forEach(questionId => {
             const li = document.createElement('li');
-            li.className = 'list-group-item';
+            li.classList.add('list-group-item');
             li.textContent = `Q${questionId}: ${answers[questionId]}`;
             answersList.appendChild(li);
         });

--- a/src/main/resources/static/js/exercise-answer-monitor.js
+++ b/src/main/resources/static/js/exercise-answer-monitor.js
@@ -28,7 +28,7 @@ export function refreshExerciseAnswerMonitor(questionId) {
             display.textContent = '受講者を選択してください';
             data.forEach(row => {
                 const li = document.createElement('li');
-                li.className = 'list-group-item list-group-item-action';
+                li.classList.add('list-group-item', 'list-group-item-action');
                 li.textContent = row.studentName;
                 li.addEventListener('click', () => {
                     display.textContent = row.answerText && row.answerText.trim() !== ''

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -106,7 +106,7 @@ function initSearch() {
     if (!searchResults) {
       const resultsContainer = document.createElement('div');
       resultsContainer.id = 'search-results';
-      resultsContainer.className = 'search-results';
+      resultsContainer.classList.add('search-results');
       this.parentNode.appendChild(resultsContainer);
     }
     
@@ -397,7 +397,7 @@ function showAlert(message, type = 'info', duration = 3000) {
   }
   
   const alert = document.createElement('div');
-  alert.className = `alert alert-${type}`;
+  alert.classList.add('alert', `alert-${type}`);
   alert.textContent = message;
   
   document.getElementById('alert-container').appendChild(alert);


### PR DESCRIPTION
## Summary
- replace `className` assignments with `classList` in answer monitor scripts
- use `classList` for dynamic element styling in main.js

## Testing
- `npm run test:e2e` *(fails: psql: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b7f2b9e5dc8324a307c366acb2f933