### PR TITLE
クイズ回答モニタでinnerHTMLを廃止

### DIFF
--- a/src/main/resources/static/js/quiz-answer-monitor.js
+++ b/src/main/resources/static/js/quiz-answer-monitor.js
@@ -23,7 +23,9 @@ export function refreshQuizAnswerMonitor(questionId) {
             if (!tbody) {
                 return;
             }
-            tbody.innerHTML = '';
+            while (tbody.firstChild) {
+                tbody.removeChild(tbody.firstChild);
+            }
             data.forEach(row => {
                 const tr = document.createElement('tr');
 
@@ -46,7 +48,15 @@ export function refreshQuizAnswerMonitor(questionId) {
             console.error('回答取得エラー', err);
             const tbody = monitor.querySelector('tbody');
             if (tbody) {
-                tbody.innerHTML = '<tr><td colspan="3">取得に失敗しました</td></tr>';
+                while (tbody.firstChild) {
+                    tbody.removeChild(tbody.firstChild);
+                }
+                const row = document.createElement('tr');
+                const cell = document.createElement('td');
+                cell.colSpan = 3;
+                cell.textContent = '取得に失敗しました';
+                row.appendChild(cell);
+                tbody.appendChild(row);
             }
         });
 }


### PR DESCRIPTION
## Summary
- `quiz-answer-monitor.js`で`innerHTML`の使用を廃止し、DOM操作でエラー表示を追加

## Testing
- `npm test` *(missing script: test)*
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68b7f3937ac48324a0c2833f49f03945