### PR TITLE
既存クイズ回答を上書き保存できるように修正

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/domain/repository/StudentAnswerRepository.java
+++ b/src/main/java/jp/co/apsa/giiku/domain/repository/StudentAnswerRepository.java
@@ -1,6 +1,7 @@
 package jp.co.apsa.giiku.domain.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import jp.co.apsa.giiku.domain.entity.StudentAnswer;
@@ -14,6 +15,16 @@ import jp.co.apsa.giiku.domain.entity.StudentAnswer;
  */
 @Repository
 public interface StudentAnswerRepository extends JpaRepository<StudentAnswer, Long> {
+
+    /**
+     * クイズID、質問ID、学生IDで回答を取得
+     *
+     * @param quizId クイズID
+     * @param questionId 質問ID
+     * @param studentId 学生ID
+     * @return 回答
+     */
+    Optional<StudentAnswer> findByQuizIdAndQuestionIdAndStudentId(Long quizId, Long questionId, Long studentId);
 
     /**
      * クイズIDと学生IDで回答を取得

--- a/src/main/java/jp/co/apsa/giiku/service/StudentAnswerService.java
+++ b/src/main/java/jp/co/apsa/giiku/service/StudentAnswerService.java
@@ -38,7 +38,18 @@ public class StudentAnswerService {
         answer.setQuestionId(questionId);
         answer.setStudentId(studentId);
         answer.setAnswerText(answerText);
-        answer.setSubmittedAt(LocalDateTime.now());
+
+        studentAnswerRepository
+                .findByQuizIdAndQuestionIdAndStudentId(quizId, questionId, studentId)
+                .ifPresent(existing -> {
+                    answer.setId(existing.getId());
+                    answer.setSubmittedAt(LocalDateTime.now());
+                });
+
+        if (answer.getSubmittedAt() == null) {
+            answer.setSubmittedAt(LocalDateTime.now());
+        }
+
         return studentAnswerRepository.save(answer);
     }
 


### PR DESCRIPTION
## 概要
- クイズID・質問ID・学生IDが一致する既存回答を検索し、存在する場合は同じIDで上書き保存
- 学生回答リポジトリに検索メソッドを追加

## テスト
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68b7f9d3a3748324a96b8744ae2bcf4c