### PR TITLE
refactor: move lecture submissions to event listeners

### DIFF
--- a/src/main/resources/static/js/lecture-exercise.js
+++ b/src/main/resources/static/js/lecture-exercise.js
@@ -50,3 +50,13 @@ async function submitExerciseAnswer(questionId, lectureId, answerText) {
         }
     }
 }
+
+document.querySelectorAll('.exercise-submit-btn').forEach(button => {
+    button.addEventListener('click', () => {
+        const questionId = button.dataset.questionId;
+        const lectureId = button.dataset.lectureId;
+        const input = document.getElementById(`exercise-input-${questionId}`);
+        const answerText = input ? input.value : '';
+        submitExerciseAnswer(questionId, lectureId, answerText);
+    });
+});

--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -59,3 +59,11 @@ async function submitQuizAnswer(quizId, questionId) {
         console.error('Failed to submit answer', error);
     }
 }
+
+document.querySelectorAll('.quiz-submit-btn').forEach(button => {
+    button.addEventListener('click', () => {
+        const quizId = button.dataset.quizId;
+        const questionId = button.dataset.questionId;
+        submitQuizAnswer(quizId, questionId);
+    });
+});

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -156,7 +156,8 @@
                             </li>
                         </ol>
                         <div class="mt-2">
-                            <button class="btn btn-success" th:onclick="|submitQuizAnswer(${quiz.id}, ${quiz.id})|">回答送信</button>
+                            <button class="btn btn-success quiz-submit-btn"
+                                    th:attr="data-quiz-id=${quiz.id},data-question-id=${quiz.id}">回答送信</button>
                             <div th:id="'quiz-result-' + ${quiz.id}" class="mt-2"></div>
                         </div>
                         <div sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')">
@@ -205,7 +206,8 @@
                         <div class="mb-3">
                             <textarea class="form-control" th:id="|exercise-input-${exercise.id}|" rows="3" placeholder="回答を入力してください"></textarea>
                         </div>
-                        <button class="btn btn-success" th:onclick="|submitExerciseAnswer(${exercise.id}, ${lecture.id}, document.getElementById('exercise-input-${exercise.id}').value)|">
+                        <button class="btn btn-success exercise-submit-btn"
+                                th:attr="data-question-id=${exercise.id},data-lecture-id=${lecture.id}">
                             <i class="fas fa-paper-plane me-1"></i>送信
                         </button>
                         <div th:id="|exercise-result-${exercise.id}|" class="mt-2"></div>


### PR DESCRIPTION
## Summary
- remove inline submit handlers for quiz/exercise buttons
- register click listeners in JS using data attributes

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_68b8c5a52b5c8324b674b6f78faa1786