### PR TITLE
Replace innerHTML clearing with DOM node removal loops

### DIFF
--- a/src/main/resources/static/js/dashboard-answer.js
+++ b/src/main/resources/static/js/dashboard-answer.js
@@ -27,7 +27,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function renderFeed(answers) {
-        feedEl.innerHTML = '';
+        while (feedEl.firstChild) {
+            feedEl.removeChild(feedEl.firstChild);
+        }
         Object.keys(answers).forEach(questionId => {
             const li = document.createElement('li');
             li.classList.add('list-group-item');

--- a/src/main/resources/static/js/exercise-answer-monitor.js
+++ b/src/main/resources/static/js/exercise-answer-monitor.js
@@ -24,7 +24,9 @@ export function refreshExerciseAnswerMonitor(questionId) {
             if (!list || !display) {
                 return;
             }
-            list.innerHTML = '';
+            while (list.firstChild) {
+                list.removeChild(list.firstChild);
+            }
             display.textContent = '受講者を選択してください';
             data.forEach(row => {
                 const li = document.createElement('li');


### PR DESCRIPTION
## Summary
- avoid using `innerHTML` to clear elements in answer monitor scripts
- use DOM child removal loops for student list and answer feed

## Testing
- `./gradlew test`
- `npm run test:e2e` *(fails: psql: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b8c6c385f083248f24288abc474277