### PR TITLE
回答モニタの空データ表示を改善

### DIFF
--- a/src/main/resources/static/js/exercise-answer-monitor.js
+++ b/src/main/resources/static/js/exercise-answer-monitor.js
@@ -28,6 +28,14 @@ export function refreshExerciseAnswerMonitor(questionId) {
                 list.removeChild(list.firstChild);
             }
             display.textContent = '受講者を選択してください';
+            if (data.length === 0) {
+                const li = document.createElement('li');
+                li.classList.add('list-group-item');
+                li.textContent = '回答なし';
+                list.appendChild(li);
+                display.textContent = '回答なし';
+                return;
+            }
             data.forEach(row => {
                 const li = document.createElement('li');
                 li.classList.add('list-group-item', 'list-group-item-action');

--- a/src/main/resources/static/js/quiz-answer-monitor.js
+++ b/src/main/resources/static/js/quiz-answer-monitor.js
@@ -26,6 +26,15 @@ export function refreshQuizAnswerMonitor(questionId) {
             while (tbody.firstChild) {
                 tbody.removeChild(tbody.firstChild);
             }
+            if (data.length === 0) {
+                const row = document.createElement('tr');
+                const cell = document.createElement('td');
+                cell.colSpan = 3;
+                cell.textContent = '回答なし';
+                row.appendChild(cell);
+                tbody.appendChild(row);
+                return;
+            }
             data.forEach(row => {
                 const tr = document.createElement('tr');
 


### PR DESCRIPTION
## 概要
- クイズ回答モニタで回答が0件の場合に「回答なし」を表示
- 演習回答モニタで回答が0件の場合に学生リストと表示欄へ「回答なし」を表示

## テスト
- `npm test`（スクリプト未定義）

------
https://chatgpt.com/codex/tasks/task_b_68b8c794adc08324bde6aadfb4cfbcc4