### PR TITLE
lecture.html の th:utext を th:text に変更

### DIFF
--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -91,7 +91,7 @@
                                     <div th:switch="${#strings.toLowerCase(block.blockType)}">
                                         <!-- テキストコンテンツ -->
                                         <div th:case="'text'">
-                                            <pre class="formatted-text" th:utext="${block.content}">コンテンツ内容</pre>
+                                            <pre class="formatted-text" th:text="${block.content}">コンテンツ内容</pre>
                                         </div>
 
                                         <!-- コードブロック -->
@@ -106,12 +106,12 @@
 
                                         <!-- リスト -->
                                         <div th:case="'list'">
-                                            <pre class="formatted-text" th:utext="${block.content}">リスト内容</pre>
+                                            <pre class="formatted-text" th:text="${block.content}">リスト内容</pre>
                                         </div>
 
                                         <!-- その他のコンテンツ -->
                                         <div th:case="*">
-                                            <pre class="formatted-text" th:utext="${block.content}">その他のコンテンツ</pre>
+                                            <pre class="formatted-text" th:text="${block.content}">その他のコンテンツ</pre>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
## Summary
- lecture.html 内の `th:utext` を `th:text` に置き換え、HTML はサーバ側サニタイズ後のみ表示

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68b8c83e34f88324ac4db267c77382eb