### PR TITLE
API応答のContent-Type検証を追加

### DIFF
--- a/src/main/resources/static/js/exercise-answer-monitor.js
+++ b/src/main/resources/static/js/exercise-answer-monitor.js
@@ -16,6 +16,10 @@ export function refreshExerciseAnswerMonitor(questionId) {
             if (!response.ok) {
                 throw new Error('HTTP error');
             }
+            const contentType = response.headers.get('content-type') || '';
+            if (!contentType.includes('application/json')) {
+                throw new Error('Invalid content type');
+            }
             return response.json();
         })
         .then(data => {

--- a/src/main/resources/static/js/quiz-answer-monitor.js
+++ b/src/main/resources/static/js/quiz-answer-monitor.js
@@ -16,6 +16,10 @@ export function refreshQuizAnswerMonitor(questionId) {
             if (!response.ok) {
                 throw new Error('HTTP error');
             }
+            const contentType = response.headers.get('content-type') || '';
+            if (!contentType.includes('application/json')) {
+                throw new Error('Invalid content type');
+            }
             return response.json();
         })
         .then(data => {


### PR DESCRIPTION
## Summary
- クイズ回答モニターと演習回答モニターでAPI応答のContent-Typeを検証
- JSON以外の応答時にはエラー扱いとして表示を更新

## Testing
- `npm run test:e2e` *(psql: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b8cc67f0b88324b31379397cdc911f