### PR TITLE
子要素を個別に削除してリストをクリア

### DIFF
--- a/src/main/resources/static/js/answer-monitor.js
+++ b/src/main/resources/static/js/answer-monitor.js
@@ -41,7 +41,9 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     function renderAnswers(answers) {
-        answersList.innerHTML = '';
+        while (answersList.firstChild) {
+            answersList.removeChild(answersList.firstChild);
+        }
         Object.keys(answers).forEach(questionId => {
             const li = document.createElement('li');
             li.classList.add('list-group-item');


### PR DESCRIPTION
## 概要
- answer-monitor.jsでinnerHTMLによるリストクリアをDOM操作に変更

## テスト
- `npm run test:e2e` (psql未インストールのため失敗)


------
https://chatgpt.com/codex/tasks/task_b_68b8ccf5c6b883249386c18b90460333