### PR TITLE
クイズ回答送信時に正しいクイズIDを使用

### DIFF
--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -1,7 +1,7 @@
 import { getCsrfToken } from './csrf.js';
 import { refreshQuizAnswerMonitor } from './quiz-answer-monitor.js';
 
-async function submitQuizAnswer(quizId, questionId) {
+async function submitQuizAnswer(quizSessionId, questionId) {
     const studentInput = document.getElementById('studentId');
     const studentId = studentInput ? studentInput.value : null;
 
@@ -38,7 +38,7 @@ async function submitQuizAnswer(quizId, questionId) {
         const response = await fetch(`/api/quizzes/questions/${questionId}/answer`, {
             method: 'POST',
             headers: headers,
-            body: JSON.stringify({ quizId, studentId, answer })
+            body: JSON.stringify({ quizId: quizSessionId, studentId, answer })
         });
         if (!response.ok) {
             throw new Error('Network response was not ok');
@@ -62,8 +62,8 @@ async function submitQuizAnswer(quizId, questionId) {
 
 document.querySelectorAll('.quiz-submit-btn').forEach(button => {
     button.addEventListener('click', () => {
-        const quizId = button.dataset.quizId;
+        const quizSessionId = button.dataset.quizId;
         const questionId = button.dataset.questionId;
-        submitQuizAnswer(quizId, questionId);
+        submitQuizAnswer(quizSessionId, questionId);
     });
 });

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -157,7 +157,7 @@
                         </ol>
                         <div class="mt-2">
                             <button class="btn btn-success quiz-submit-btn"
-                                    th:attr="data-quiz-id=${quiz.id},data-question-id=${quiz.id}">回答送信</button>
+                                    th:attr="data-quiz-id=${quiz.quizId},data-question-id=${quiz.id}">回答送信</button>
                             <div th:id="'quiz-result-' + ${quiz.id}" class="mt-2"></div>
                         </div>
                         <div sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')">


### PR DESCRIPTION
## 概要
- 理解度テストの回答送信ボタンに実クイズIDを設定
- 実クイズIDに合わせて回答送信処理の引数と送信内容を修正

## テスト
- `./gradlew test`
- `npm run test:e2e` : psql が無く失敗

------
https://chatgpt.com/codex/tasks/task_b_68b8cdbc4ce88324a9200bba95c099fe