### PR TITLE
Refactor answer toggle buttons

### DIFF
--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -67,3 +67,21 @@ document.querySelectorAll('.quiz-submit-btn').forEach(button => {
         submitQuizAnswer(quizSessionId, questionId);
     });
 });
+
+document.querySelectorAll('.show-answer-btn').forEach(button => {
+    button.addEventListener('click', () => {
+        const targetId = button.dataset.targetId;
+        if (typeof window.showAnswer === 'function') {
+            window.showAnswer(targetId);
+        }
+    });
+});
+
+document.querySelectorAll('.toggle-answer-btn').forEach(button => {
+    button.addEventListener('click', () => {
+        const targetId = button.dataset.targetId;
+        if (typeof window.toggleAnswer === 'function') {
+            window.toggleAnswer(targetId);
+        }
+    });
+});

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -161,8 +161,8 @@
                             <div th:id="'quiz-result-' + ${quiz.id}" class="mt-2"></div>
                         </div>
                         <div sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')">
-                            <button th:onclick="'showAnswer(\'quiz-answer' + ${quizStat.count} + '\')'"
-                                    class="btn btn-primary d-flex align-items-center gap-2 mt-2">
+                            <button class="btn btn-primary d-flex align-items-center gap-2 mt-2 show-answer-btn"
+                                    th:attr="data-target-id=|quiz-answer${quizStat.count}|">
                                 <i class="fas fa-eye"></i>
                                 <span class="answer-toggle-label">回答を表示</span>
                             </button>
@@ -212,8 +212,8 @@
                         </button>
                         <div th:id="|exercise-result-${exercise.id}|" class="mt-2"></div>
                         <button sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')"
-                                th:onclick="'toggleAnswer(\'exercise-answer' + ${exStat.count} + '\')'"
-                                class="btn btn-primary d-flex align-items-center gap-2">
+                                class="btn btn-primary d-flex align-items-center gap-2 toggle-answer-btn"
+                                th:attr="data-target-id=|exercise-answer${exStat.count}|">
                             <i class="fas fa-eye"></i>
                             <span class="answer-toggle-label">回答例を表示</span>
                         </button>
@@ -291,7 +291,7 @@
                 const isShown = answerElement.classList.toggle('show');
 
                 // ボタンテキストを変更
-                const button = document.querySelector(`[onclick*="${answerId}"]`);
+                const button = document.querySelector(`[data-target-id="${answerId}"]`);
                 if (button) {
                     const icon = button.querySelector('i');
                     const label = button.querySelector('.answer-toggle-label');
@@ -314,7 +314,7 @@
                 const isShown = answerElement.classList.toggle('show');
 
                 // ボタンテキストを変更
-                const button = document.querySelector(`[onclick*="${answerId}"]`);
+                const button = document.querySelector(`[data-target-id="${answerId}"]`);
                 if (button) {
                     const icon = button.querySelector('i');
                     const label = button.querySelector('.answer-toggle-label');


### PR DESCRIPTION
## Summary
- replace inline `th:onclick` handlers with `.show-answer-btn`/`.toggle-answer-btn` and `data-target-id`
- add JS listeners in `lecture-quiz.js` to invoke `showAnswer`/`toggleAnswer`
- update toggle functions to query buttons via `data-target-id`

## Testing
- `npm run test:e2e` *(fails: command not found: npm)*
- `apt-get install -y nodejs npm` *(fails: Unable to locate package nodejs)*

------
https://chatgpt.com/codex/tasks/task_b_68b8ced6d4c083248a58e5832f397c55