### PR TITLE
講義ページで答案監視スクリプトの直接読み込みを削除

### DIFF
--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -345,8 +345,6 @@
     <script th:src="@{/webjars/prismjs/components/prism-sql.js}"></script>
     <script th:src="@{/js/lecture-quiz.js}" type="module"></script>
     <script th:src='@{/js/lecture-exercise.js}' type="module"></script>
-    <script th:src="@{/js/quiz-answer-monitor.js}" type="module"></script>
-    <script th:src="@{/js/exercise-answer-monitor.js}" type="module"></script>
 </section>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- `lecture.html` から `quiz-answer-monitor.js` と `exercise-answer-monitor.js` の `<script>` タグを削除
- `lecture-quiz.js` と `lecture-exercise.js` の `import` のみに統一

## Testing
- `npm test` *(script missing)*
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68b8cfcfad2c83249097c0e3e98df0ef