### PR TITLE
fix: CORS設定で明示的なオリジンを指定

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/infrastructure/config/AppConfig.java
+++ b/src/main/java/jp/co/apsa/giiku/infrastructure/config/AppConfig.java
@@ -18,8 +18,8 @@ public class AppConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOriginPatterns("*")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedOriginPatterns("https://example.com") // 必要なオリジンを列挙
+                .allowedMethods("GET","POST","PUT","DELETE","OPTIONS")
                 .allowCredentials(true);
     }
 }


### PR DESCRIPTION
## Summary
- CORS設定で`allowedOriginPatterns`に`https://example.com`を指定し、ワイルドカードを廃止

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_b_68b8d2be0f5883248f7271a9467881b9