### PR TITLE
fix: クイズ送信ボタンに質問IDを設定

### DIFF
--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -157,7 +157,7 @@
                         </ol>
                         <div class="mt-2">
                             <button class="btn btn-success quiz-submit-btn"
-                                    th:attr="data-quiz-id=${quiz.quizId},data-question-id=${quiz.id}">回答送信</button>
+                                    th:attr="data-quiz-id=${quiz.id},data-question-id=${quiz.id}">回答送信</button>
                             <div th:id="'quiz-result-' + ${quiz.id}" class="mt-2"></div>
                         </div>
                         <div sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')">


### PR DESCRIPTION
## 概要
- 理解度テスト送信ボタンの `data-quiz-id` に `quiz.id` を使用するよう修正

## テスト
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_b_68b8db48de748324a80fde9224b3fcee