### PR TITLE
クイズ回答送信時のID指定修正

### DIFF
--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -1,7 +1,7 @@
 import { getCsrfToken } from './csrf.js';
 import { refreshQuizAnswerMonitor } from './quiz-answer-monitor.js';
 
-async function submitQuizAnswer(quizSessionId, questionId) {
+async function submitQuizAnswer(quizId, questionId) {
     const studentInput = document.getElementById('studentId');
     const studentId = studentInput ? studentInput.value : null;
 
@@ -38,7 +38,7 @@ async function submitQuizAnswer(quizSessionId, questionId) {
         const response = await fetch(`/api/quizzes/questions/${questionId}/answer`, {
             method: 'POST',
             headers: headers,
-            body: JSON.stringify({ quizId: quizSessionId, studentId, answer })
+            body: JSON.stringify({ quizId, studentId, answer })
         });
         if (!response.ok) {
             throw new Error('Network response was not ok');
@@ -62,9 +62,9 @@ async function submitQuizAnswer(quizSessionId, questionId) {
 
 document.querySelectorAll('.quiz-submit-btn').forEach(button => {
     button.addEventListener('click', () => {
-        const quizSessionId = button.dataset.quizId;
+        const quizId = button.dataset.quizId;
         const questionId = button.dataset.questionId;
-        submitQuizAnswer(quizSessionId, questionId);
+        submitQuizAnswer(quizId, questionId);
     });
 });
 

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -157,7 +157,7 @@
                         </ol>
                         <div class="mt-2">
                             <button class="btn btn-success quiz-submit-btn"
-                                    th:attr="data-quiz-id=${quiz.id},data-question-id=${quiz.id}">回答送信</button>
+                                    th:data-quiz-id="${quiz.id}" th:data-question-id="${quiz.id}">回答送信</button>
                             <div th:id="'quiz-result-' + ${quiz.id}" class="mt-2"></div>
                         </div>
                         <div sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')">


### PR DESCRIPTION
## Summary
- クイズ回答送信APIへ送るIDパラメータを`quizId`へ統一
- テンプレートのクイズ送信ボタンに`data-quiz-id`を明示

## Testing
- `npm run test:e2e` *(psql が無いため失敗)*

------
https://chatgpt.com/codex/tasks/task_b_68b8f9eb845083249e179300739a956d