### PR TITLE
演習回答モニタのデータ属性と更新処理の修正

### DIFF
--- a/src/main/resources/static/js/lecture-exercise.js
+++ b/src/main/resources/static/js/lecture-exercise.js
@@ -11,6 +11,7 @@ async function submitExerciseAnswer(questionId, lectureId, answerText) {
             resultEl.classList.remove('text-success', 'text-danger');
             resultEl.classList.add('text-danger');
         }
+        refreshExerciseAnswerMonitor(questionId);
         return;
     }
     if (!answerText || answerText.trim() === '') {
@@ -19,6 +20,7 @@ async function submitExerciseAnswer(questionId, lectureId, answerText) {
             resultEl.classList.remove('text-success', 'text-danger');
             resultEl.classList.add('text-danger');
         }
+        refreshExerciseAnswerMonitor(questionId);
         return;
     }
     try {
@@ -40,7 +42,6 @@ async function submitExerciseAnswer(questionId, lectureId, answerText) {
             resultEl.classList.remove('text-success', 'text-danger');
             resultEl.classList.add('text-success');
         }
-        refreshExerciseAnswerMonitor(questionId);
     } catch (error) {
         console.error('Failed to submit exercise answer', error);
         if (resultEl) {
@@ -48,6 +49,8 @@ async function submitExerciseAnswer(questionId, lectureId, answerText) {
             resultEl.classList.remove('text-success', 'text-danger');
             resultEl.classList.add('text-danger');
         }
+    } finally {
+        refreshExerciseAnswerMonitor(questionId);
     }
 }
 

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -224,8 +224,9 @@
                             <p th:text="${exercise.correctAnswer}">回答</p>
                             <p th:if="${exercise.explanation}" th:text="${exercise.explanation}">解説</p>
                         </div>
-                        <div class="exercise-answer-monitor mt-3" sec:authorize="hasRole('INSTRUCTOR')"
-                             th:attr="data-question-id=${exercise.id}">
+                        <div class="exercise-answer-monitor mt-3"
+                             sec:authorize="hasRole('INSTRUCTOR')"
+                             th:data-question-id="${exercise.id}">
                             <h5 class="fw-bold text-primary mb-2">
                                 <i class="fas fa-user-check me-2"></i>演習回答一覧
                             </h5>


### PR DESCRIPTION
## Summary
- `exercise-answer-monitor` に `th:data-question-id` 属性を追加
- 演習回答送信後に常に `refreshExerciseAnswerMonitor` が呼ばれるように修正

## Testing
- `npm test` (Missing script: "test")
- `./gradlew test`
- `xdg-open src/main/resources/templates/index.html`

------
https://chatgpt.com/codex/tasks/task_b_68b9067d347c8324a1a2aff2ce36037d