### PR TITLE
クイズ・演習回答モニタのセッション切れ対応

### DIFF
--- a/src/main/resources/static/js/exercise-answer-monitor.js
+++ b/src/main/resources/static/js/exercise-answer-monitor.js
@@ -11,18 +11,24 @@ export function refreshExerciseAnswerMonitor(questionId) {
         return;
     }
 
-    fetch(`/api/question-banks/${questionId}/answers`)
+    fetch(`/api/question-banks/${questionId}/answers`, {
+        headers: { 'Accept': 'application/json' }
+    })
         .then(response => {
             if (!response.ok) {
                 throw new Error('HTTP error');
             }
             const contentType = response.headers.get('content-type') || '';
             if (!contentType.includes('application/json')) {
-                throw new Error('Invalid content type');
+                monitor.textContent = 'セッションが切れました';
+                return null;
             }
             return response.json();
         })
         .then(data => {
+            if (!data) {
+                return;
+            }
             const list = monitor.querySelector('.exercise-student-list');
             const display = monitor.querySelector('.exercise-answer-display');
             if (!list || !display) {

--- a/src/main/resources/static/js/quiz-answer-monitor.js
+++ b/src/main/resources/static/js/quiz-answer-monitor.js
@@ -11,18 +11,24 @@ export function refreshQuizAnswerMonitor(questionId) {
         return;
     }
 
-    fetch(`/api/quizzes/questions/${questionId}/answers`)
+    fetch(`/api/quizzes/questions/${questionId}/answers`, {
+        headers: { 'Accept': 'application/json' }
+    })
         .then(response => {
             if (!response.ok) {
                 throw new Error('HTTP error');
             }
             const contentType = response.headers.get('content-type') || '';
             if (!contentType.includes('application/json')) {
-                throw new Error('Invalid content type');
+                monitor.textContent = 'セッションが切れました';
+                return null;
             }
             return response.json();
         })
         .then(data => {
+            if (!data) {
+                return;
+            }
             const tbody = monitor.querySelector('tbody');
             if (!tbody) {
                 return;


### PR DESCRIPTION
## Summary
- クイズ回答モニタでAcceptヘッダーを追加し、HTML応答時にセッション切れを表示
- 演習回答モニタでも同様のAcceptヘッダーとセッション切れ処理を実装

## Testing
- `npm run test:e2e` *(psql: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ba1508674883249b06bf537d7423d9