### PR TITLE
クイズ送信時にセッションIDを使用するよう修正

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
@@ -102,6 +102,7 @@ public class LectureViewController extends AbstractController {
         setTitle(model, lecture.getTitle());
         model.addAttribute("pageTitle", lecture.getTitle());
         model.addAttribute("lecture", lecture);
+        model.addAttribute("quizSessionId", lecture.getId());
         // 以前は回答モニタ用のquestionIdをモデルに追加していたが現在は不要
 
         // 正規化されたテーブルからデータを取得

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -157,7 +157,7 @@
                         </ol>
                         <div class="mt-2">
                             <button class="btn btn-success quiz-submit-btn"
-                                    th:data-quiz-id="${quiz.id}" th:data-question-id="${quiz.id}">回答送信</button>
+                                    th:data-quiz-id="${quizSessionId}" th:data-question-id="${quiz.id}">回答送信</button>
                             <div th:id="'quiz-result-' + ${quiz.id}" class="mt-2"></div>
                         </div>
                         <div sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')">


### PR DESCRIPTION
## 概要
- クイズ送信ボタンで実際のクイズセッションIDを送信するように変更
- LectureViewControllerでquizSessionIdをモデルへ追加

## テスト
- `./gradlew build`
- `xdg-open src/main/resources/templates/index.html` (command not found)


------
https://chatgpt.com/codex/tasks/task_b_68ba225f34608324a397ea8193809bef