### PR TITLE
feat: modularize answer toggle functions

### DIFF
--- a/src/main/resources/static/js/answer-toggle.js
+++ b/src/main/resources/static/js/answer-toggle.js
@@ -1,0 +1,45 @@
+export function showAnswer(answerId) {
+    const answerElement = document.getElementById(answerId);
+    if (!answerElement) {
+        return;
+    }
+
+    const isShown = answerElement.classList.toggle('show');
+    const button = document.querySelector(`[data-target-id="${answerId}"]`);
+    if (button) {
+        const icon = button.querySelector('i');
+        const label = button.querySelector('.answer-toggle-label');
+        if (icon && label) {
+            if (isShown) {
+                icon.className = 'fas fa-eye-slash';
+                label.textContent = '回答を非表示';
+            } else {
+                icon.className = 'fas fa-eye';
+                label.textContent = '回答を表示';
+            }
+        }
+    }
+}
+
+export function toggleAnswer(answerId) {
+    const answerElement = document.getElementById(answerId);
+    if (!answerElement) {
+        return;
+    }
+
+    const isShown = answerElement.classList.toggle('show');
+    const button = document.querySelector(`[data-target-id="${answerId}"]`);
+    if (button) {
+        const icon = button.querySelector('i');
+        const label = button.querySelector('.answer-toggle-label');
+        if (icon && label) {
+            if (isShown) {
+                icon.className = 'fas fa-eye-slash';
+                label.textContent = '回答例を非表示';
+            } else {
+                icon.className = 'fas fa-eye';
+                label.textContent = '回答例を表示';
+            }
+        }
+    }
+}

--- a/src/main/resources/static/js/lecture-quiz.js
+++ b/src/main/resources/static/js/lecture-quiz.js
@@ -1,5 +1,6 @@
 import { getCsrfToken } from './csrf.js';
 import { refreshQuizAnswerMonitor } from './quiz-answer-monitor.js';
+import { showAnswer, toggleAnswer } from './answer-toggle.js';
 
 async function submitQuizAnswer(quizId, questionId) {
     const studentInput = document.getElementById('studentId');
@@ -71,17 +72,13 @@ document.querySelectorAll('.quiz-submit-btn').forEach(button => {
 document.querySelectorAll('.show-answer-btn').forEach(button => {
     button.addEventListener('click', () => {
         const targetId = button.dataset.targetId;
-        if (typeof window.showAnswer === 'function') {
-            window.showAnswer(targetId);
-        }
+        showAnswer(targetId);
     });
 });
 
 document.querySelectorAll('.toggle-answer-btn').forEach(button => {
     button.addEventListener('click', () => {
         const targetId = button.dataset.targetId;
-        if (typeof window.toggleAnswer === 'function') {
-            window.toggleAnswer(targetId);
-        }
+        toggleAnswer(targetId);
     });
 });

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -286,52 +286,6 @@
 
     <!-- JavaScript -->
     <script>
-        function showAnswer(answerId) {
-            const answerElement = document.getElementById(answerId);
-            if (answerElement) {
-                const isShown = answerElement.classList.toggle('show');
-
-                // ボタンテキストを変更
-                const button = document.querySelector(`[data-target-id="${answerId}"]`);
-                if (button) {
-                    const icon = button.querySelector('i');
-                    const label = button.querySelector('.answer-toggle-label');
-                    if (icon && label) {
-                        if (isShown) {
-                            icon.className = 'fas fa-eye-slash';
-                            label.textContent = '回答を非表示';
-                        } else {
-                            icon.className = 'fas fa-eye';
-                            label.textContent = '回答を表示';
-                        }
-                    }
-                }
-            }
-        }
-
-        function toggleAnswer(answerId) {
-            const answerElement = document.getElementById(answerId);
-            if (answerElement) {
-                const isShown = answerElement.classList.toggle('show');
-
-                // ボタンテキストを変更
-                const button = document.querySelector(`[data-target-id="${answerId}"]`);
-                if (button) {
-                    const icon = button.querySelector('i');
-                    const label = button.querySelector('.answer-toggle-label');
-                    if (icon && label) {
-                        if (isShown) {
-                            icon.className = 'fas fa-eye-slash';
-                            label.textContent = '回答例を非表示';
-                        } else {
-                            icon.className = 'fas fa-eye';
-                            label.textContent = '回答例を表示';
-                        }
-                    }
-                }
-            }
-        }
-
         // コードブロックの構文ハイライト
         document.addEventListener('DOMContentLoaded', function() {
             if (typeof Prism !== 'undefined') {
@@ -344,6 +298,7 @@
     <script th:src="@{/webjars/prismjs/prism.js}"></script>
     <script th:src="@{/webjars/prismjs/components/prism-java.js}"></script>
     <script th:src="@{/webjars/prismjs/components/prism-sql.js}"></script>
+    <script type="module" th:src="@{/js/answer-toggle.js}"></script>
     <script th:src="@{/js/lecture-quiz.js}" type="module"></script>
     <script th:src='@{/js/lecture-exercise.js}' type="module"></script>
 </section>


### PR DESCRIPTION
## Summary
- move answer toggle logic to new ES module
- load module in lecture page instead of inline functions
- invoke modular functions from lecture quiz script

## Testing
- `npm test` *(fails: Missing script "test")*
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68ba2651f5e08324823e4248e1c79ebd