### PR TITLE
quizSessionIdの削除とテンプレートの修正

### DIFF
--- a/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
+++ b/src/main/java/jp/co/apsa/giiku/controller/LectureViewController.java
@@ -102,7 +102,6 @@ public class LectureViewController extends AbstractController {
         setTitle(model, lecture.getTitle());
         model.addAttribute("pageTitle", lecture.getTitle());
         model.addAttribute("lecture", lecture);
-        model.addAttribute("quizSessionId", lecture.getId());
         // 以前は回答モニタ用のquestionIdをモデルに追加していたが現在は不要
 
         // 正規化されたテーブルからデータを取得

--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -144,7 +144,7 @@
                         </ol>
                         <div class="mt-2">
                             <button class="btn btn-success quiz-submit-btn"
-                                    th:data-quiz-id="${quizSessionId}" th:data-question-id="${quiz.id}">回答送信</button>
+                                    th:data-quiz-id="${quiz.id}" th:data-question-id="${quiz.id}">回答送信</button>
                             <div th:id="'quiz-result-' + ${quiz.id}" class="mt-2"></div>
                         </div>
                         <div sec:authorize="hasAnyRole('ADMIN','INSTRUCTOR')">


### PR DESCRIPTION
## Summary
- 不要となった`quizSessionId`属性を`LectureViewController`から削除
- クイズ送信ボタンの`data-quiz-id`を`quiz.id`に変更

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_b_68ba435cf24c8324b09153d90ec6a465