### PR TITLE
Render quiz options from list items

### DIFF
--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -135,8 +135,8 @@
                     <h3 class="fw-semibold mb-3" th:text="${chapter.chapterNumber + '. ' + chapter.title}"></h3>
                     <div th:each="quiz, quizStat : ${quizQuestionsByChapter[chapter.id]}" class="mb-4">
                         <h4 class="fw-semibold mb-2" th:text="${quiz.questionNumber + '. ' + quiz.questionText}">問題文</h4>
-                        <ol class="quiz-options list-unstyled" th:each="choice, stat : ${quiz.choiceList}">
-                            <li class="d-flex align-items-center">
+                        <ol class="quiz-options list-unstyled">
+                            <li class="d-flex align-items-center" th:each="choice, stat : ${quiz.choiceList}">
                                 <input class="me-2" th:attr="name=${'quiz-' + quiz.id}, value=${choice}, type=${quiz.questionType == 'MULTI' ? 'checkbox' : 'radio'}" />
                                 <span class="me-2" th:text="${stat.count + '.'}"></span>
                                 <span th:text="${choice}"></span>


### PR DESCRIPTION
## Summary
- Render quiz options by iterating over list items instead of the ordered list
- Confirm quiz option CSS is loaded via base layout

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_b_68ba5d541fc08324aef2f92920b670b9