### PR TITLE
Refactor quiz choice markup in lecture template

### DIFF
--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -136,9 +136,15 @@
                     <div th:each="quiz, quizStat : ${quizQuestionsByChapter[chapter.id]}" class="mb-4">
                         <h4 class="fw-semibold mb-2" th:text="${quiz.questionNumber + '. ' + quiz.questionText}">問題文</h4>
                         <ol class="quiz-options">
-                            <li class="d-flex align-items-center" th:each="choice : ${quiz.choiceList}">
-                                <input class="me-2" th:attr="name=${'quiz-' + quiz.id}, value=${choice}, type=${quiz.questionType == 'MULTI' ? 'checkbox' : 'radio'}" />
-                                <span th:text="${choice}"></span>
+                            <li th:each="choice, stat : ${quiz.choiceList}">
+                                <label class="d-flex align-items-center">
+                                    <input class="me-2"
+                                           th:attr="name=${'quiz-' + quiz.id},
+                                                    value=${choice},
+                                                    type=${quiz.questionType == 'MULTI' ? 'checkbox' : 'radio'}"/>
+                                    <span class="me-2" th:text="${stat.count + '.'}"></span>
+                                    <span th:text="${choice}"></span>
+                                </label>
                             </li>
                         </ol>
                         <div class="mt-2">


### PR DESCRIPTION
## Summary
- wrap quiz choices in label for accessible selection and numbering
- add explicit numbering for choices via stat.count

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_b_68bc3bf9b58c83248ea145c72fbb4eb2