### PR TITLE
Fix quiz option numbering and submission

### DIFF
--- a/src/main/resources/templates/lecture.html
+++ b/src/main/resources/templates/lecture.html
@@ -135,12 +135,19 @@
                     <h3 class="fw-semibold mb-3" th:text="${chapter.chapterNumber + '. ' + chapter.title}"></h3>
                     <div th:each="quiz, quizStat : ${quizQuestionsByChapter[chapter.id]}" class="mb-4">
                         <h4 class="fw-semibold mb-2" th:text="${quiz.questionNumber + '. ' + quiz.questionText}">問題文</h4>
-                        <ol class="quiz-options">
-                            <li class="d-flex align-items-center" th:each="choice : ${quiz.choiceList}">
-                                <input class="me-2" th:attr="name=${'quiz-' + quiz.id}, value=${choice}, type=${quiz.questionType == 'MULTI' ? 'checkbox' : 'radio'}" />
-                                <span th:text="${choice}"></span>
+                        <ul class="quiz-options">
+                            <li th:each="choice, stat : ${quiz.choiceList}">
+                                <label class="d-flex align-items-center">
+                                    <input class="me-2"
+                                           th:attr="id=${'quiz-' + quiz.id + '-choice-' + stat.count},
+                                                    name=${'quiz-' + quiz.id},
+                                                    value=${stat.count},
+                                                    type=${quiz.questionType == 'MULTI' ? 'checkbox' : 'radio'}"/>
+                                    <span class="me-2" th:text="${stat.count + '.'}"></span>
+                                    <span th:text="${choice}"></span>
+                                </label>
                             </li>
-                        </ol>
+                        </ul>
                         <div class="mt-2">
                             <button class="btn btn-success quiz-submit-btn"
                                     th:data-quiz-id="${quiz.id}" th:data-question-id="${quiz.id}">回答送信</button>


### PR DESCRIPTION
## Summary
- avoid duplicate numbering and supply numeric values for quiz choices

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68bc3bf9b58c83248ea145c72fbb4eb2